### PR TITLE
fix: switch to OpenRouter API for embeddings

### DIFF
--- a/src/lib/llm/embedding.ts
+++ b/src/lib/llm/embedding.ts
@@ -10,7 +10,7 @@ export async function embedText(env: Env, contents: string[]): Promise<number[][
       Authorization: `Bearer ${env.LLM_OPENROUTER_APIKEY}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ model, input: contents }),
+    body: JSON.stringify({ model, input: contents, dimensions: 1536 }),
   });
 
   if (!resp.ok) throw new Error(`embedding error ${resp.status}: ${await resp.text()}`);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -33,9 +33,9 @@ max_retries = 3
 crons = ["0 */2 * * *", "0 * * * *", "0 */3 * * *"]
 
 [vars]
-LLM_OPENROUTER_BASEURL = "https://api.gptsapi.net/v1"
+LLM_OPENROUTER_BASEURL = "https://openrouter.ai/api/v1"
 LLM_OPENROUTER_MODEL = "gpt-4o-mini"
-LLM_OPENROUTER_EMBEDDINGMODEL = "text-embedding-ada-002"
+LLM_OPENROUTER_EMBEDDINGMODEL = "qwen/qwen3-embedding-8b"
 LLM_DEEPSEEK_BASEURL = "https://api.deepseek.com/v1"
 LLM_DEEPSEEK_MODEL = "deepseek-chat"
 LLM_DEEPSEEK_REASONINGEFFORT = "high"


### PR DESCRIPTION
## Summary
- Switch  from third-party proxy (`gptsapi.net`) to the official OpenRouter API (`openrouter.ai`)
- Add `dimensions: 1536` parameter to embedding requests for Matryoshka truncation (qwen model outputs 4096-dim natively, Vectorize max is 1536)
- Recreate Vectorize indexes at 1536 dimensions

## Changes
- `wrangler.toml` — update base URL to `https://openrouter.ai/api/v1`
- `src/lib/llm/embedding.ts` — add `dimensions: 1536` to API request body

## Deploy Checklist
- [ ] Rotate `LLM_OPENROUTER_APIKEY` secret with a valid OpenRouter API key