### PR TITLE
fix: Vectorize returnMetadata boolean -> string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export default {
         }
         msg.ack();
       } catch (err) {
-        console.error(`[queue] ${type} failed:`, err);
+        console.error(`[queue] ${type} failed:`, err, msg.body);
         msg.retry({ delaySeconds: 60 });
       }
     }

--- a/src/lib/vectorize/index.ts
+++ b/src/lib/vectorize/index.ts
@@ -20,7 +20,7 @@ export async function getVectorById(index: any, id: string): Promise<number[] | 
 }
 
 export async function querySimilar(index: any, vector: number[], topK = 30): Promise<{ id: string; score: number }[]> {
-  const r = await index.query(vector, { topK, returnValues: false, returnMetadata: false });
+  const r = await index.query(vector, { topK, returnValues: false, returnMetadata: "none" });
   return (r.matches ?? []).map((m: any) => ({ id: m.id, score: m.score }));
 }
 


### PR DESCRIPTION
## Summary

- Fix VECTOR_QUERY_ERROR (40026) by changing `returnMetadata: false` to `returnMetadata: "none"` in Vectorize query options. The Cloudflare Vectorize API expects a string ("none" | "indexed" | "all"), not a boolean.
- Log `msg.body` in queue error handler for easier debugging.