### PR TITLE
fix: eliminate duplicate Telegram notifications from cron overlap

### DIFF
--- a/src/jobs/notify.ts
+++ b/src/jobs/notify.ts
@@ -1,6 +1,10 @@
 import type { Env, UserMatchedDetailJob } from "../lib/types.js";
 import { getAllUserInfoCount, getUserInfoList } from "../lib/db/user_info.js";
-import { getUserNonNotifiedJobTotalCount, getUserNonNotifiedJobList, updateAllMatchJobNotified } from "../lib/db/user_matched_job.js";
+import {
+  getUserNonNotifiedJobTotalCount,
+  getUserNonNotifiedJobList,
+  updateMatchJobsNotifiedByIds,
+} from "../lib/db/user_matched_job.js";
 
 function buildMessage(jobs: UserMatchedDetailJob[]): string {
   let msg = "You have new matched jobs, please check.\n\n";
@@ -27,9 +31,11 @@ export async function sendJobsInChunks(env: Env, telegramId: string, jobs: UserM
 
   while (pendingJobs.length > 0) {
     const batch = pendingJobs.slice(0, batchSize);
+    const batchJobIds = batch.map((j) => j.id);
     const resp = await sendTelegramMessage(env.TELEGRAM_BOT_TOKEN, telegramId, buildMessage(batch));
 
     if (resp.ok) {
+      await updateMatchJobsNotifiedByIds(env.DB, userId, batchJobIds);
       pendingJobs = pendingJobs.slice(batchSize);
       batchSize = pendingJobs.length;
       continue;
@@ -38,6 +44,7 @@ export async function sendJobsInChunks(env: Env, telegramId: string, jobs: UserM
     if (resp.description?.includes("message is too long")) {
       if (batch.length <= 1) {
         console.log(`[notify] skipping too-long job ${batch[0].id} for user ${userId}`);
+        await updateMatchJobsNotifiedByIds(env.DB, userId, [batch[0].id]);
         pendingJobs = pendingJobs.slice(1);
         batchSize = pendingJobs.length;
         continue;
@@ -53,25 +60,38 @@ export async function sendJobsInChunks(env: Env, telegramId: string, jobs: UserM
 }
 
 export async function handleNotify(env: Env): Promise<void> {
-  const total = await getAllUserInfoCount(env.DB);
-  if (!total) { console.log("[notify] no users"); return; }
+  const LOCK_KEY = "notify-last-run";
+  const LOCK_TTL = 60;
 
-  const BATCH = 100;
-  for (let off = 0; off < total; off += BATCH) {
-    const users = await getUserInfoList(env.DB, off, BATCH);
-    for (const u of users) {
-      if (!u.telegramId) continue;
-      try {
-        const cnt = await getUserNonNotifiedJobTotalCount(env.DB, u.id);
-        if (!cnt) continue;
-        const jobs = await getUserNonNotifiedJobList(env.DB, u.id, 0, 10);
-        if (!jobs.length) continue;
-
-        await sendJobsInChunks(env, u.telegramId, jobs, u.id);
-        await updateAllMatchJobNotified(env.DB, u.id);
-        console.log(`[notify] notified user ${u.id} (${u.telegramId})`);
-      } catch (e) { console.error(`[notify] failed for user ${u.id}:`, e); }
-    }
+  const existing = await env.SESSION_KV.get(LOCK_KEY);
+  if (existing) {
+    console.log("[notify] skipped — another notify run is in progress");
+    return;
   }
-  console.log("[notify] done");
+  await env.SESSION_KV.put(LOCK_KEY, "1", { expirationTtl: LOCK_TTL });
+
+  try {
+    const total = await getAllUserInfoCount(env.DB);
+    if (!total) { console.log("[notify] no users"); return; }
+
+    const BATCH = 100;
+    for (let off = 0; off < total; off += BATCH) {
+      const users = await getUserInfoList(env.DB, off, BATCH);
+      for (const u of users) {
+        if (!u.telegramId) continue;
+        try {
+          const cnt = await getUserNonNotifiedJobTotalCount(env.DB, u.id);
+          if (!cnt) continue;
+          const jobs = await getUserNonNotifiedJobList(env.DB, u.id, 0, 10);
+          if (!jobs.length) continue;
+
+          await sendJobsInChunks(env, u.telegramId, jobs, u.id);
+          console.log(`[notify] notified user ${u.id} (${u.telegramId})`);
+        } catch (e) { console.error(`[notify] failed for user ${u.id}:`, e); }
+      }
+    }
+    console.log("[notify] done");
+  } finally {
+    await env.SESSION_KV.delete(LOCK_KEY);
+  }
 }

--- a/src/lib/db/user_matched_job.ts
+++ b/src/lib/db/user_matched_job.ts
@@ -54,6 +54,15 @@ export async function updateAllMatchJobNotified(db: D1Database, userId: string):
   await db.prepare("UPDATE user_matched_job SET notification=1 WHERE user_id=? AND notification=0").bind(userId).run();
 }
 
+export async function updateMatchJobsNotifiedByIds(db: D1Database, userId: string, jobIds: string[]): Promise<void> {
+  if (!jobIds.length) return;
+  const placeholders = jobIds.map(() => "?").join(",");
+  await db
+    .prepare(`UPDATE user_matched_job SET notification=1 WHERE user_id=? AND job_id IN (${placeholders})`)
+    .bind(userId, ...jobIds)
+    .run();
+}
+
 function mapRow(row: Record<string, unknown>): UserMatchedDetailJob {
   return {
     id: row.id as string,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,14 +30,14 @@ max_batch_size = 1
 max_retries = 3
 
 [triggers]
-crons = ["0 */2 * * *", "0 * * * *", "0 */3 * * *"]
+crons = ["0 * * * *"]
 
 [vars]
 LLM_OPENROUTER_BASEURL = "https://openrouter.ai/api/v1"
 LLM_OPENROUTER_MODEL = "gpt-4o-mini"
 LLM_OPENROUTER_EMBEDDINGMODEL = "qwen/qwen3-embedding-8b"
 LLM_DEEPSEEK_BASEURL = "https://api.deepseek.com/v1"
-LLM_DEEPSEEK_MODEL = "deepseek-chat"
+LLM_DEEPSEEK_MODEL = "deepseek-v4-flash"
 LLM_DEEPSEEK_REASONINGEFFORT = "high"
 
 [observability.logs]


### PR DESCRIPTION
### Problem
Duplicate Telegram notifications (3x) sent at hours divisible by 6 (0, 6, 12, 18 UTC) due to multiple cron expressions firing simultaneously, each enqueuing independent notify jobs.

### Root Cause
1. Three overlapping cron schedules in `wrangler.toml` caused `scheduled()` to run 3 times concurrently at certain hours
2. No idempotency mechanism in `handleNotify` — concurrent executions read the same unnotified jobs before any marks them
3. Jobs were marked notified only after all chunks sent, causing re-sends on partial-failure retries

### Changes
- **wrangler.toml**: Merge 3 cron expressions into single `0 * * * *` (hourly check already handles per-job-type scheduling internally)
- **src/jobs/notify.ts**: Add KV-based idempotency lock with 60s TTL to prevent concurrent notify runs
- **src/jobs/notify.ts + src/lib/db/user_matched_job.ts**: Mark individual jobs as notified after each successful Telegram send chunk instead of bulk at the end
- **wrangler.toml**: Switch `LLM_DEEPSEEK_MODEL` to `deepseek-v4-flash`