### PR TITLE
feat: skip already-matched jobs to avoid redundant LLM calls

### DIFF
--- a/src/jobs/match.test.ts
+++ b/src/jobs/match.test.ts
@@ -6,6 +6,7 @@ const {
   mockGetUsersWithResume,
   mockGetJobDetailsByIds,
   mockCreateMatchJobIfNotExist,
+  mockGetExistingMatchedJobIds,
   mockGetVectorById,
   mockQuerySimilar,
   mockRunMatchAgent,
@@ -13,6 +14,7 @@ const {
   mockGetUsersWithResume: vi.fn(),
   mockGetJobDetailsByIds: vi.fn(),
   mockCreateMatchJobIfNotExist: vi.fn(),
+  mockGetExistingMatchedJobIds: vi.fn(),
   mockGetVectorById: vi.fn(),
   mockQuerySimilar: vi.fn(),
   mockRunMatchAgent: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock("../lib/db/job_detail", () => ({
 
 vi.mock("../lib/db/user_matched_job", () => ({
   createMatchJobIfNotExist: mockCreateMatchJobIfNotExist,
+  getExistingMatchedJobIds: mockGetExistingMatchedJobIds,
 }));
 
 vi.mock("../lib/vectorize/index", () => ({
@@ -136,6 +139,7 @@ describe("handleMatch", () => {
     mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);
     mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }]);
     mockGetJobDetailsByIds.mockResolvedValue([recentJob]);
+    mockGetExistingMatchedJobIds.mockResolvedValue([]);
     mockRunMatchAgent.mockResolvedValue([
       {
         jobId: "job-1",
@@ -166,6 +170,7 @@ describe("handleMatch", () => {
     mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);
     mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }]);
     mockGetJobDetailsByIds.mockResolvedValue([recentJob]);
+    mockGetExistingMatchedJobIds.mockResolvedValue([]);
     mockRunMatchAgent.mockResolvedValue([
       {
         jobId: "job-1",
@@ -193,10 +198,61 @@ describe("handleMatch", () => {
     mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);
     mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }]);
     mockGetJobDetailsByIds.mockResolvedValue([recentJob]);
+    mockGetExistingMatchedJobIds.mockResolvedValue([]);
     mockRunMatchAgent.mockResolvedValue([]);
 
     await handleMatch(makeEnv(), 0);
 
     expect(mockCreateMatchJobIfNotExist).not.toHaveBeenCalled();
+  });
+
+  it("skips runMatchAgent when all jobs are already matched", async () => {
+    mockGetUsersWithResume.mockResolvedValue([userWithResume]);
+    mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);
+    mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }, { id: "job-2", score: 0.85 }]);
+    mockGetJobDetailsByIds.mockResolvedValue([
+      { ...recentJob, id: "job-1" },
+      { ...recentJob, id: "job-2", title: "Job 2" },
+    ]);
+    mockGetExistingMatchedJobIds.mockResolvedValue(["job-1", "job-2"]);
+
+    await handleMatch(makeEnv(), 0);
+
+    expect(mockRunMatchAgent).not.toHaveBeenCalled();
+    expect(mockCreateMatchJobIfNotExist).not.toHaveBeenCalled();
+  });
+
+  it("filters out already-matched jobs and only sends new ones to agent", async () => {
+    mockGetUsersWithResume.mockResolvedValue([userWithResume]);
+    mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);
+    mockQuerySimilar.mockResolvedValue([
+      { id: "job-1", score: 0.95 },
+      { id: "job-2", score: 0.85 },
+      { id: "job-3", score: 0.80 },
+    ]);
+    mockGetJobDetailsByIds.mockResolvedValue([
+      { ...recentJob, id: "job-1" },
+      { ...recentJob, id: "job-2", title: "Job 2" },
+      { ...recentJob, id: "job-3", title: "Job 3" },
+    ]);
+    mockGetExistingMatchedJobIds.mockResolvedValue(["job-1", "job-3"]);
+    mockRunMatchAgent.mockResolvedValue([
+      {
+        jobId: "job-2",
+        jobTitle: "Job 2",
+        jobLink: "https://example.com/job/1",
+        matchScore: "8",
+        reason: "Good match for job 2",
+      },
+    ]);
+
+    await handleMatch(makeEnv(), 0);
+
+    expect(mockGetExistingMatchedJobIds).toHaveBeenCalledWith({}, "user-1", ["job-1", "job-2", "job-3"]);
+    expect(mockRunMatchAgent).toHaveBeenCalledTimes(1);
+    const agentInput = mockRunMatchAgent.mock.calls[0][0];
+    expect(agentInput.jobs).toHaveLength(1);
+    expect(agentInput.jobs[0].jobId).toBe("job-2");
+    expect(mockCreateMatchJobIfNotExist).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/jobs/match.ts
+++ b/src/jobs/match.ts
@@ -1,7 +1,7 @@
 import type { Env, UserMatchedJobPromptInput } from "../lib/types.js";
 import { getUsersWithResume } from "../lib/db/user_info.js";
 import { getJobDetailsByIds } from "../lib/db/job_detail.js";
-import { createMatchJobIfNotExist } from "../lib/db/user_matched_job.js";
+import { createMatchJobIfNotExist, getExistingMatchedJobIds } from "../lib/db/user_matched_job.js";
 import { getVectorById, querySimilar } from "../lib/vectorize/index.js";
 import { runMatchAgent } from "../lib/agent/index.js";
 
@@ -36,7 +36,16 @@ export async function handleMatch(env: Env, offset: number): Promise<void> {
     return;
   }
 
-  const input: UserMatchedJobPromptInput[] = jobs.map((j) => ({
+  const existingIds = await getExistingMatchedJobIds(env.DB, user.id, jobs.map((j) => j.id));
+  console.log(`[match] user ${user.id}: similar=${hits.length} recent=${jobs.length} already_matched=${existingIds.length}`);
+
+  const newJobs = jobs.filter((j) => !existingIds.includes(j.id));
+  if (!newJobs.length) {
+    console.log(`[match] all ${jobs.length} jobs already matched for user ${user.id}, skipping`);
+    return;
+  }
+
+  const input: UserMatchedJobPromptInput[] = newJobs.map((j) => ({
     jobId: j.id, jobTitle: j.title, jobLink: j.link, jobDescription: j.jobDesc, location: j.location, salary: j.salary,
   }));
 

--- a/src/lib/db/user_matched_job.ts
+++ b/src/lib/db/user_matched_job.ts
@@ -50,6 +50,16 @@ export async function getUserNonNotifiedJobTotalCount(db: D1Database, userId: st
   return r?.count ?? 0;
 }
 
+export async function getExistingMatchedJobIds(db: D1Database, userId: string, jobIds: string[]): Promise<string[]> {
+  if (!jobIds.length) return [];
+  const placeholders = jobIds.map(() => "?").join(",");
+  const rows = await db
+    .prepare(`SELECT job_id FROM user_matched_job WHERE user_id = ? AND job_id IN (${placeholders})`)
+    .bind(userId, ...jobIds)
+    .all<{ job_id: string }>();
+  return (rows.results ?? []).map((r) => r.job_id);
+}
+
 export async function updateAllMatchJobNotified(db: D1Database, userId: string): Promise<void> {
   await db.prepare("UPDATE user_matched_job SET notification=1 WHERE user_id=? AND notification=0").bind(userId).run();
 }


### PR DESCRIPTION
## Problem
`handleMatch` sent all 30 similar jobs to `runMatchAgent` every cron run, even when most were already matched. This wasted LLM tokens and API calls.

## Solution
Added `getExistingMatchedJobIds()` that bulk-checks which job IDs already exist in `user_matched_job` for a given user. Before calling the agent, filter out already-matched jobs.

### Flow
```
hits (30) → recent (N) → already_matched (M) → new (N-M) → runMatchAgent
```

### Log output
```
[match] user X: similar=30 recent=22 already_matched=19
[match] stored 2 matches for user X
```
Or when nothing new:
```
[match] user X: similar=30 recent=22 already_matched=22
[match] all 22 jobs already matched for user X, skipping
```

## Files changed
| File | Change |
|------|--------|
| `src/lib/db/user_matched_job.ts` | Add `getExistingMatchedJobIds(userId, jobIds[])` |
| `src/jobs/match.ts` | Filter already-matched jobs + logging |
| `src/jobs/match.test.ts` | 2 new tests for filtering behavior |