### PR TITLE
feat: move match agent to Cloudflare Containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,20 +9,35 @@
 - **Vector search**: Cloudflare Vectorize
 - **Session state**: Cloudflare KV
 - **Async jobs**: Cloudflare Queues
-- **Cron triggers**: 3 schedules, all enqueue to the job queue
+- **Cron triggers**: Single hourly cron (`0 * * * *`), handler dispatches job types based on hour
+- **AI SDK**: Vercel AI SDK (`ai` + `@ai-sdk/openai`) for agent-based job matching
+- **Embeddings**: OpenRouter API (Qwen3 embedding model)
+- **LLM chat**: DeepSeek API via OpenAI-compatible endpoint
 
 ## Project Structure
 
 ```
-├── wrangler.toml              # Single config — D1, KV, Vectorize, Queue, Cron
+├── wrangler.toml              # Config: D1, KV, Vectorize, Queue, Cron, observability
 ├── src/
 │   ├── index.ts               # Entry: Hono routes + scheduled() + queue()
 │   ├── lib/
 │   │   ├── types.ts           # All type definitions + Env bindings
+│   │   ├── config.ts          # Config helper reading env bindings
+│   │   ├── agent/
+│   │   │   ├── index.ts       # Re-exports
+│   │   │   ├── match_agent.ts # Vercel AI SDK agent: tool-based job matching (getPendingJobs / submitEvaluation)
+│   │   │   └── match_agent.test.ts
 │   │   ├── db/                # D1 CRUD (job_detail, user_info, user_matched_job)
-│   │   ├── llm/               # OpenRouter embeddings + DeepSeek chat + prompt
-│   │   ├── crawler/           # RemoteOK + WeWorkRemotely scrapers
-│   │   └── vectorize/         # Vectorize upsert/query helpers
+│   │   ├── llm/
+│   │   │   ├── index.ts       # Old LLM helpers (OpenRouter chat)
+│   │   │   └── embedding.ts   # OpenRouter embeddings
+│   │   ├── crawler/
+│   │   │   ├── index.ts       # Crawler registry
+│   │   │   ├── remote_ok.ts   # RemoteOK scraper
+│   │   │   └── weworkremotely.ts # WeWorkRemotely scraper
+│   │   └── vectorize/
+│   │       ├── index.ts       # Vectorize upsert/query helpers
+│   │       └── mock.ts        # Mock Vectorize for testing
 │   ├── bot/
 │   │   ├── bot.ts             # grammY setup + env middleware + command registration
 │   │   ├── session.ts         # KV-backed chat session (10min TTL)
@@ -31,8 +46,10 @@
 │   └── jobs/
 │       ├── crawl.ts           # Fetch jobs from RemoteOK + WeWorkRemotely
 │       ├── embed.ts           # Generate embeddings → store in Vectorize
-│       ├── match.ts           # Vector search → DeepSeek → store matches
-│       └── notify.ts          # Unnotified matches → Telegram API
+│       ├── match.ts           # Vector search → AI agent (Vercel AI SDK) → store matches
+│       ├── match.test.ts
+│       ├── notify.ts          # Unnotified matches → Telegram API
+│       └── notify.test.ts
 └── migrations/
     └── 001_initial.sql        # D1 schema
 ```
@@ -40,8 +57,16 @@
 ## Flow
 
 ```
-Cron        ──▶  scheduled()  ──▶  JOBS_QUEUE.send({type})  ──▶  queue() → dispatch
-Telegram    ──▶  Hono POST /webhook  ──▶  grammY bot  ──▶  command handlers
+Cron (hourly)               ──▶  scheduled()  ──▶  JOBS_QUEUE.send({type, offset})
+(crawl on even hours)       ──▶  JOBS_QUEUE.send({type: "crawl"})
+(embed every hour)          ──▶  JOBS_QUEUE.send({type: "embed"})
+(match/notify every 3 hrs)  ──▶  JOBS_QUEUE.send({type: "match", offset: i}) + notify
+
+Telegram  ──▶  Hono POST /telegram/webhook  ──▶  grammY bot  ──▶  command handlers
+
+Job match pipeline:
+  Vectorize similar search  ──▶  filter recent + unmatched  ──▶  runMatchAgent (Vercel AI SDK)
+  ──▶  tool calls: getPendingJobs / submitEvaluation  ──▶  store matches in user_matched_job
 ```
 
 ## Commands
@@ -88,3 +113,21 @@ npx wrangler deploy
 # 9. Set Telegram webhook
 curl -X POST "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://jd-matcher.<subdomain>.workers.dev/telegram/webhook"
 ```
+
+## Testing
+
+```bash
+npx vitest run            # Run all tests
+npx vitest run --reporter=verbose  # Verbose output
+```
+
+## Scripts
+
+| Script | Description |
+|---|---|
+| `npm run dev` | Start wrangler dev server |
+| `npm run dev:cron` | Dev server with test-scheduled flag |
+| `npm run dev:db` | Apply migration to local D1 |
+| `npm run deploy` | Deploy to Cloudflare |
+| `npm run test` | Run vitest tests |
+| `npm run typecheck` | TypeScript type check |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+CMD ["npx", "tsx", "src/container/server.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@cloudflare/containers": "^0.3.7",
         "@cloudflare/workers-types": "^4.20250301.0",
+        "tsx": "^4.22.4",
         "typescript": "^5.7.0",
         "vitest": "^4.1.7",
         "wrangler": "^4.0.0"
@@ -82,6 +84,13 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",
@@ -3039,6 +3048,509 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@cloudflare/containers": "^0.3.7",
     "@cloudflare/workers-types": "^4.20250301.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.0",
     "vitest": "^4.1.7",
     "wrangler": "^4.0.0"

--- a/src/container/server.test.ts
+++ b/src/container/server.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from "vitest";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+
+const mockRunMatchAgent = vi.fn();
+
+vi.mock("../lib/agent/match_agent.js", () => ({
+  runMatchAgent: mockRunMatchAgent,
+  buildSystemPrompt: vi.fn((r: string, e: string) => `system: ${r} / ${e}`),
+}));
+
+// Dynamic import after mock is set up
+const serverModule = await import("./server.js");
+const { handleRequest } = serverModule;
+
+let server: Server;
+let port: number;
+
+beforeAll(async () => {
+  process.env.LLM_DEEPSEEK_APIKEY = process.env.LLM_DEEPSEEK_APIKEY || "test-key";
+  server = createServer(handleRequest);
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => resolve());
+  });
+  port = (server.address() as { port: number }).port;
+  console.log(`[test] container server on port ${port}`);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  mockRunMatchAgent.mockReset();
+});
+
+function makeSampleJobs() {
+  return [
+    {
+      jobId: "test-job-1",
+      jobTitle: "Senior TypeScript Developer",
+      jobLink: "https://example.com/job/1",
+      jobDescription: "TypeScript, React, Node.js. 5+ years.",
+      location: "Remote",
+      salary: "$120k-$160k",
+    },
+    {
+      jobId: "test-job-2",
+      jobTitle: "Junior Python Developer",
+      jobLink: "https://example.com/job/2",
+      jobDescription: "Python, Django. Entry level.",
+      location: "New York, NY",
+      salary: "$50k-$70k",
+    },
+  ];
+}
+
+describe("Container server integration", () => {
+  it("GET /health returns OK", async () => {
+    const resp = await fetch(`http://localhost:${port}/health`);
+    expect(resp.status).toBe(200);
+    expect(await resp.text()).toBe("OK");
+  });
+
+  it("POST /match forwards correct data to runMatchAgent", async () => {
+    const matchedJobs = [
+      { jobId: "test-job-1", jobTitle: "Senior TypeScript Developer", jobLink: "https://example.com/job/1", matchScore: "9", reason: "Perfect match" },
+    ];
+    mockRunMatchAgent.mockResolvedValue(matchedJobs);
+
+    const jobs = makeSampleJobs();
+    const resp = await fetch(`http://localhost:${port}/match`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        resume: "TypeScript dev, 8 years",
+        expectations: "$120k+, Remote",
+        jobs,
+      }),
+    });
+
+    expect(resp.status).toBe(200);
+    const data = await resp.json();
+    expect(data).toEqual(matchedJobs);
+
+    // Verify runMatchAgent was called with correct params
+    expect(mockRunMatchAgent).toHaveBeenCalledTimes(1);
+    const callArgs = mockRunMatchAgent.mock.calls[0][0];
+    expect(callArgs.resume).toBe("TypeScript dev, 8 years");
+    expect(callArgs.expectations).toBe("$120k+, Remote");
+    expect(callArgs.jobs).toEqual(jobs);
+    expect(callArgs.apiKey).toBe("test-key");
+    expect(callArgs.baseURL).toBe("https://api.deepseek.com/v1");
+    expect(callArgs.modelName).toBe("deepseek-v4-flash");
+    expect(callArgs.reasoningEffort).toBe("high");
+  });
+
+  it("POST /match uses custom env vars when set", async () => {
+    const origBaseURL = process.env.LLM_DEEPSEEK_BASEURL;
+    const origModel = process.env.LLM_DEEPSEEK_MODEL;
+    const origEffort = process.env.LLM_DEEPSEEK_REASONINGEFFORT;
+    process.env.LLM_DEEPSEEK_BASEURL = "https://custom.api/v1";
+    process.env.LLM_DEEPSEEK_MODEL = "custom-model";
+    process.env.LLM_DEEPSEEK_REASONINGEFFORT = "low";
+
+    mockRunMatchAgent.mockResolvedValue([]);
+
+    const resp = await fetch(`http://localhost:${port}/match`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resume: "r", expectations: "", jobs: [] }),
+    });
+
+    expect(resp.status).toBe(200);
+
+    const callArgs = mockRunMatchAgent.mock.calls[0][0];
+    expect(callArgs.baseURL).toBe("https://custom.api/v1");
+    expect(callArgs.modelName).toBe("custom-model");
+    expect(callArgs.reasoningEffort).toBe("low");
+
+    process.env.LLM_DEEPSEEK_BASEURL = origBaseURL;
+    process.env.LLM_DEEPSEEK_MODEL = origModel;
+    process.env.LLM_DEEPSEEK_REASONINGEFFORT = origEffort;
+  });
+
+  it("POST /match returns 500 on agent error", async () => {
+    mockRunMatchAgent.mockRejectedValue(new Error("API timeout"));
+
+    const resp = await fetch(`http://localhost:${port}/match`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resume: "r", expectations: "", jobs: [] }),
+    });
+
+    expect(resp.status).toBe(500);
+    const data = await resp.json();
+    expect(data.error).toContain("API timeout");
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const resp = await fetch(`http://localhost:${port}/unknown`);
+    expect(resp.status).toBe(404);
+  });
+});

--- a/src/container/server.ts
+++ b/src/container/server.ts
@@ -1,0 +1,57 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { runMatchAgent } from "../lib/agent/match_agent.js";
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+  });
+}
+
+export async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200);
+    res.end("OK");
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/match") {
+    try {
+      const body = await readBody(req);
+      const input = JSON.parse(body);
+
+      const results = await runMatchAgent({
+        resume: input.resume,
+        expectations: input.expectations,
+        jobs: input.jobs,
+        apiKey: process.env.LLM_DEEPSEEK_APIKEY!,
+        baseURL: process.env.LLM_DEEPSEEK_BASEURL || "https://api.deepseek.com/v1",
+        modelName: process.env.LLM_DEEPSEEK_MODEL || "deepseek-v4-flash",
+        reasoningEffort: process.env.LLM_DEEPSEEK_REASONINGEFFORT || "high",
+      });
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(results));
+    } catch (err) {
+      console.error("[container] match error:", err);
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: String(err) }));
+    }
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not Found");
+}
+
+const isMain = process.argv[1]?.endsWith("/server.ts") || process.argv[1]?.endsWith("/server.js");
+if (isMain) {
+  const PORT = parseInt(process.env.PORT || "3000");
+  const server = createServer(handleRequest);
+  server.listen(PORT, () => {
+    console.log(`[container] agent server listening on port ${PORT}`);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { webhookCallback } from "grammy";
+import { Container } from "@cloudflare/containers";
 import type { Env, JobMessage } from "./lib/types.js";
 import { createBot } from "./bot/bot.js";
 import { handleCrawl } from "./jobs/crawl.js";
@@ -7,6 +8,11 @@ import { handleEmbed } from "./jobs/embed.js";
 import { handleMatch } from "./jobs/match.js";
 import { handleNotify } from "./jobs/notify.js";
 import { getUsersWithResumeCount } from "./lib/db/user_info.js";
+
+export class MatchContainer extends Container {
+  defaultPort = 3000;
+  sleepAfter = "10m";
+}
 
 const app = new Hono<{ Bindings: Env }>();
 

--- a/src/jobs/agent_client.test.ts
+++ b/src/jobs/agent_client.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { callAgent } from "./agent_client.js";
+import type { Env, UserMatchedJobPromptInput } from "../lib/types.js";
+
+const mockFetch = vi.fn();
+const mockStartAndWaitForPorts = vi.fn();
+
+const { mockGetContainer } = vi.hoisted(() => ({
+  mockGetContainer: vi.fn(),
+}));
+
+vi.mock("@cloudflare/containers", () => ({
+  Container: class {},
+  getContainer: mockGetContainer,
+}));
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    TELEGRAM_BOT_TOKEN: "",
+    DB: {} as D1Database,
+    SESSION_KV: {} as KVNamespace,
+    JOB_DESC_EMBEDDINGS: {} as VectorizeIndex,
+    RESUME_EMBEDDINGS: {} as VectorizeIndex,
+    JOBS_QUEUE: {} as Queue<{ type: string }>,
+    MATCH_CONTAINER: {} as DurableObjectNamespace<import("@cloudflare/containers").Container>,
+    LLM_OPENROUTER_BASEURL: "",
+    LLM_OPENROUTER_APIKEY: "",
+    LLM_OPENROUTER_MODEL: "",
+    LLM_OPENROUTER_EMBEDDINGMODEL: "",
+    LLM_DEEPSEEK_BASEURL: "",
+    LLM_DEEPSEEK_APIKEY: "test-api-key",
+    LLM_DEEPSEEK_MODEL: "test-model",
+    LLM_DEEPSEEK_REASONINGEFFORT: "test-effort",
+    ...overrides,
+  };
+}
+
+describe("callAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartAndWaitForPorts.mockResolvedValue(undefined);
+    mockFetch.mockReset();
+    mockGetContainer.mockReturnValue({
+      startAndWaitForPorts: mockStartAndWaitForPorts,
+      fetch: mockFetch,
+    });
+  });
+
+  it("starts container with correct env vars", async () => {
+    const env = makeEnv({
+      LLM_DEEPSEEK_APIKEY: "sk-test",
+      LLM_DEEPSEEK_BASEURL: "https://custom.deepseek.com/v1",
+      LLM_DEEPSEEK_MODEL: "custom-model",
+      LLM_DEEPSEEK_REASONINGEFFORT: "low",
+    });
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await callAgent(env, "resume", "expectations", []);
+
+    expect(mockGetContainer).toHaveBeenCalledWith(env.MATCH_CONTAINER, "agent");
+    expect(mockStartAndWaitForPorts).toHaveBeenCalledWith({
+      startOptions: {
+        envVars: {
+          LLM_DEEPSEEK_APIKEY: "sk-test",
+          LLM_DEEPSEEK_BASEURL: "https://custom.deepseek.com/v1",
+          LLM_DEEPSEEK_MODEL: "custom-model",
+          LLM_DEEPSEEK_REASONINGEFFORT: "low",
+        },
+      },
+    });
+  });
+
+  it("uses defaults for optional env vars", async () => {
+    const env = makeEnv({
+      LLM_DEEPSEEK_APIKEY: "sk-test",
+      LLM_DEEPSEEK_BASEURL: "",
+      LLM_DEEPSEEK_MODEL: "",
+      LLM_DEEPSEEK_REASONINGEFFORT: "",
+    });
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await callAgent(env, "resume", "", []);
+
+    expect(mockStartAndWaitForPorts).toHaveBeenCalledWith({
+      startOptions: {
+        envVars: {
+          LLM_DEEPSEEK_APIKEY: "sk-test",
+          LLM_DEEPSEEK_BASEURL: "https://api.deepseek.com/v1",
+          LLM_DEEPSEEK_MODEL: "deepseek-v4-flash",
+          LLM_DEEPSEEK_REASONINGEFFORT: "high",
+        },
+      },
+    });
+  });
+
+  it("sends correct HTTP request to container", async () => {
+    const jobs: UserMatchedJobPromptInput[] = [
+      { jobId: "j1", jobTitle: "Job 1", jobLink: "https://x.com/1", jobDescription: "desc1", location: "Remote", salary: "$100k" },
+    ];
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await callAgent(makeEnv(), "my resume", "$120k+", jobs);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("http://container/match");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(opts.body);
+    expect(body.resume).toBe("my resume");
+    expect(body.expectations).toBe("$120k+");
+    expect(body.jobs).toEqual(jobs);
+  });
+
+  it("parses response and returns matches", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { jobId: "j1", jobTitle: "Job 1", jobLink: "https://x.com/1", matchScore: "8", reason: "Good fit" },
+          { jobId: "j2", jobTitle: "Job 2", jobLink: "https://x.com/2", matchScore: "7", reason: "OK fit" },
+        ]),
+        { status: 200 }
+      )
+    );
+
+    const result = await callAgent(makeEnv(), "r", "e", []);
+    expect(result).toHaveLength(2);
+    expect(result[0].jobId).toBe("j1");
+    expect(result[0].matchScore).toBe("8");
+    expect(result[1].reason).toBe("OK fit");
+  });
+
+  it("throws on non-200 response", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("Internal Error", { status: 500 })
+    );
+
+    await expect(callAgent(makeEnv(), "r", "e", [])).rejects.toThrow(
+      "Container agent error: 500"
+    );
+  });
+});

--- a/src/jobs/agent_client.ts
+++ b/src/jobs/agent_client.ts
@@ -1,0 +1,28 @@
+import type { Env, UserMatchedJobPromptInput, UserMatchedJobPromptOutput } from "../lib/types.js";
+import { getContainer } from "@cloudflare/containers";
+
+export async function callAgent(
+  env: Env,
+  resume: string,
+  expectations: string,
+  jobs: UserMatchedJobPromptInput[],
+): Promise<UserMatchedJobPromptOutput[]> {
+  const container = getContainer(env.MATCH_CONTAINER, "agent");
+  await container.startAndWaitForPorts({
+    startOptions: {
+      envVars: {
+        LLM_DEEPSEEK_APIKEY: env.LLM_DEEPSEEK_APIKEY,
+        LLM_DEEPSEEK_BASEURL: env.LLM_DEEPSEEK_BASEURL || "https://api.deepseek.com/v1",
+        LLM_DEEPSEEK_MODEL: env.LLM_DEEPSEEK_MODEL || "deepseek-v4-flash",
+        LLM_DEEPSEEK_REASONINGEFFORT: env.LLM_DEEPSEEK_REASONINGEFFORT || "high",
+      },
+    },
+  });
+  const resp = await container.fetch("http://container/match", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ resume, expectations, jobs }),
+  });
+  if (!resp.ok) throw new Error(`Container agent error: ${resp.status} ${await resp.text()}`);
+  return resp.json();
+}

--- a/src/jobs/match.test.ts
+++ b/src/jobs/match.test.ts
@@ -9,7 +9,7 @@ const {
   mockGetExistingMatchedJobIds,
   mockGetVectorById,
   mockQuerySimilar,
-  mockRunMatchAgent,
+  mockCallAgent,
 } = vi.hoisted(() => ({
   mockGetUsersWithResume: vi.fn(),
   mockGetJobDetailsByIds: vi.fn(),
@@ -17,7 +17,7 @@ const {
   mockGetExistingMatchedJobIds: vi.fn(),
   mockGetVectorById: vi.fn(),
   mockQuerySimilar: vi.fn(),
-  mockRunMatchAgent: vi.fn(),
+  mockCallAgent: vi.fn(),
 }));
 
 vi.mock("../lib/db/user_info", () => ({
@@ -38,8 +38,8 @@ vi.mock("../lib/vectorize/index", () => ({
   querySimilar: mockQuerySimilar,
 }));
 
-vi.mock("../lib/agent/index", () => ({
-  runMatchAgent: mockRunMatchAgent,
+vi.mock("./agent_client", () => ({
+  callAgent: mockCallAgent,
 }));
 
 function makeEnv(): Env {
@@ -50,6 +50,7 @@ function makeEnv(): Env {
     JOB_DESC_EMBEDDINGS: {} as VectorizeIndex,
     RESUME_EMBEDDINGS: {} as VectorizeIndex,
     JOBS_QUEUE: {} as Queue<{ type: string }>,
+    MATCH_CONTAINER: {} as DurableObjectNamespace<import("@cloudflare/containers").Container>,
     LLM_OPENROUTER_BASEURL: "",
     LLM_OPENROUTER_APIKEY: "",
     LLM_OPENROUTER_MODEL: "",
@@ -94,7 +95,7 @@ describe("handleMatch", () => {
 
     expect(mockGetUsersWithResume).toHaveBeenCalledTimes(1);
     expect(mockGetVectorById).not.toHaveBeenCalled();
-    expect(mockRunMatchAgent).not.toHaveBeenCalled();
+    expect(mockCallAgent).not.toHaveBeenCalled();
   });
 
   it("logs and returns when no vector found for user", async () => {
@@ -105,7 +106,7 @@ describe("handleMatch", () => {
 
     expect(mockGetVectorById).toHaveBeenCalledWith({}, "vec-user-1");
     expect(mockQuerySimilar).not.toHaveBeenCalled();
-    expect(mockRunMatchAgent).not.toHaveBeenCalled();
+    expect(mockCallAgent).not.toHaveBeenCalled();
   });
 
   it("logs and returns when no similar jobs found", async () => {
@@ -117,7 +118,7 @@ describe("handleMatch", () => {
 
     expect(mockQuerySimilar).toHaveBeenCalledWith({}, [0.1, 0.2, 0.3], 30);
     expect(mockGetJobDetailsByIds).not.toHaveBeenCalled();
-    expect(mockRunMatchAgent).not.toHaveBeenCalled();
+    expect(mockCallAgent).not.toHaveBeenCalled();
   });
 
   it("logs and returns when no recent jobs (all older than 1 month)", async () => {
@@ -131,7 +132,7 @@ describe("handleMatch", () => {
     await handleMatch(makeEnv(), 0);
 
     expect(mockGetJobDetailsByIds).toHaveBeenCalledWith({}, ["job-1"]);
-    expect(mockRunMatchAgent).not.toHaveBeenCalled();
+    expect(mockCallAgent).not.toHaveBeenCalled();
   });
 
   it("calls runMatchAgent with correct inputs for matching jobs", async () => {
@@ -140,7 +141,7 @@ describe("handleMatch", () => {
     mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }]);
     mockGetJobDetailsByIds.mockResolvedValue([recentJob]);
     mockGetExistingMatchedJobIds.mockResolvedValue([]);
-    mockRunMatchAgent.mockResolvedValue([
+    mockCallAgent.mockResolvedValue([
       {
         jobId: "job-1",
         jobTitle: "Senior TypeScript Dev",
@@ -152,17 +153,17 @@ describe("handleMatch", () => {
 
     await handleMatch(makeEnv(), 0);
 
-    expect(mockRunMatchAgent).toHaveBeenCalledTimes(1);
-    const agentInput = mockRunMatchAgent.mock.calls[0][0];
-    expect(agentInput.resume).toBe("TypeScript developer resume content");
-    expect(agentInput.expectations).toBe("Remote only, $120k minimum");
-    expect(agentInput.jobs).toHaveLength(1);
-    expect(agentInput.jobs[0].jobId).toBe("job-1");
-    expect(agentInput.jobs[0].jobTitle).toBe("Senior TypeScript Dev");
-    expect(agentInput.jobs[0].jobLink).toBe("https://example.com/job/1");
-    expect(agentInput.jobs[0].location).toBe("Remote");
-    expect(agentInput.jobs[0].salary).toBe("$120k-$160k");
-    expect(agentInput.jobs[0].jobDescription).toBe("Looking for a senior developer with TS experience.");
+    expect(mockCallAgent).toHaveBeenCalledTimes(1);
+    const callArgs = mockCallAgent.mock.calls[0];
+    expect(callArgs[1]).toBe("TypeScript developer resume content");
+    expect(callArgs[2]).toBe("Remote only, $120k minimum");
+    expect(callArgs[3]).toHaveLength(1);
+    expect(callArgs[3][0].jobId).toBe("job-1");
+    expect(callArgs[3][0].jobTitle).toBe("Senior TypeScript Dev");
+    expect(callArgs[3][0].jobLink).toBe("https://example.com/job/1");
+    expect(callArgs[3][0].location).toBe("Remote");
+    expect(callArgs[3][0].salary).toBe("$120k-$160k");
+    expect(callArgs[3][0].jobDescription).toBe("Looking for a senior developer with TS experience.");
   });
 
   it("stores matched jobs via createMatchJobIfNotExist", async () => {
@@ -171,7 +172,7 @@ describe("handleMatch", () => {
     mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }]);
     mockGetJobDetailsByIds.mockResolvedValue([recentJob]);
     mockGetExistingMatchedJobIds.mockResolvedValue([]);
-    mockRunMatchAgent.mockResolvedValue([
+    mockCallAgent.mockResolvedValue([
       {
         jobId: "job-1",
         jobTitle: "Senior TypeScript Dev",
@@ -199,7 +200,7 @@ describe("handleMatch", () => {
     mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }]);
     mockGetJobDetailsByIds.mockResolvedValue([recentJob]);
     mockGetExistingMatchedJobIds.mockResolvedValue([]);
-    mockRunMatchAgent.mockResolvedValue([]);
+    mockCallAgent.mockResolvedValue([]);
 
     await handleMatch(makeEnv(), 0);
 
@@ -218,7 +219,7 @@ describe("handleMatch", () => {
 
     await handleMatch(makeEnv(), 0);
 
-    expect(mockRunMatchAgent).not.toHaveBeenCalled();
+    expect(mockCallAgent).not.toHaveBeenCalled();
     expect(mockCreateMatchJobIfNotExist).not.toHaveBeenCalled();
   });
 
@@ -236,7 +237,7 @@ describe("handleMatch", () => {
       { ...recentJob, id: "job-3", title: "Job 3" },
     ]);
     mockGetExistingMatchedJobIds.mockResolvedValue(["job-1", "job-3"]);
-    mockRunMatchAgent.mockResolvedValue([
+    mockCallAgent.mockResolvedValue([
       {
         jobId: "job-2",
         jobTitle: "Job 2",
@@ -249,10 +250,10 @@ describe("handleMatch", () => {
     await handleMatch(makeEnv(), 0);
 
     expect(mockGetExistingMatchedJobIds).toHaveBeenCalledWith({}, "user-1", ["job-1", "job-2", "job-3"]);
-    expect(mockRunMatchAgent).toHaveBeenCalledTimes(1);
-    const agentInput = mockRunMatchAgent.mock.calls[0][0];
-    expect(agentInput.jobs).toHaveLength(1);
-    expect(agentInput.jobs[0].jobId).toBe("job-2");
+    expect(mockCallAgent).toHaveBeenCalledTimes(1);
+    const callArgs = mockCallAgent.mock.calls[0];
+    expect(callArgs[3]).toHaveLength(1);
+    expect(callArgs[3][0].jobId).toBe("job-2");
     expect(mockCreateMatchJobIfNotExist).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/jobs/match.ts
+++ b/src/jobs/match.ts
@@ -3,7 +3,7 @@ import { getUsersWithResume } from "../lib/db/user_info.js";
 import { getJobDetailsByIds } from "../lib/db/job_detail.js";
 import { createMatchJobIfNotExist, getExistingMatchedJobIds } from "../lib/db/user_matched_job.js";
 import { getVectorById, querySimilar } from "../lib/vectorize/index.js";
-import { runMatchAgent } from "../lib/agent/index.js";
+import { callAgent } from "./agent_client.js";
 
 function oneMonthAgo(): string {
   const d = new Date(); d.setMonth(d.getMonth() - 1); return d.toISOString().split("T")[0];
@@ -49,15 +49,12 @@ export async function handleMatch(env: Env, offset: number): Promise<void> {
     jobId: j.id, jobTitle: j.title, jobLink: j.link, jobDescription: j.jobDesc, location: j.location, salary: j.salary,
   }));
 
-  const parsed = await runMatchAgent({
-    resume: user.resume ?? "",
-    expectations: user.jobExpectations ?? "",
-    jobs: input,
-    apiKey: env.LLM_DEEPSEEK_APIKEY,
-    baseURL: env.LLM_DEEPSEEK_BASEURL || "https://api.deepseek.com/v1",
-    modelName: env.LLM_DEEPSEEK_MODEL || "deepseek-v4-flash",
-    reasoningEffort: env.LLM_DEEPSEEK_REASONINGEFFORT || "high",
-  });
+  const parsed = await callAgent(
+    env,
+    user.resume ?? "",
+    user.jobExpectations ?? "",
+    input,
+  );
 
   if (parsed.length) {
     await createMatchJobIfNotExist(env.DB, parsed.map((p) => ({ userId: user.id, jobId: p.jobId, notification: false, matchScore: p.matchScore, matchReason: p.reason })));

--- a/src/jobs/notify.test.ts
+++ b/src/jobs/notify.test.ts
@@ -28,6 +28,7 @@ function makeEnv(): Env {
     JOB_DESC_EMBEDDINGS: {} as VectorizeIndex,
     RESUME_EMBEDDINGS: {} as VectorizeIndex,
     JOBS_QUEUE: {} as Queue<{ type: string }>,
+    MATCH_CONTAINER: {} as DurableObjectNamespace<import("@cloudflare/containers").Container>,
     LLM_OPENROUTER_BASEURL: "",
     LLM_OPENROUTER_APIKEY: "",
     LLM_OPENROUTER_MODEL: "",

--- a/src/lib/agent/index.ts
+++ b/src/lib/agent/index.ts
@@ -1,1 +1,1 @@
-export { runMatchAgent } from "./match_agent.js";
+export { runMatchAgent, buildSystemPrompt } from "./match_agent.js";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface Env {
   JOB_DESC_EMBEDDINGS: VectorizeIndex;
   RESUME_EMBEDDINGS: VectorizeIndex;
   JOBS_QUEUE: Queue<JobMessage>;
+  MATCH_CONTAINER: DurableObjectNamespace<import("@cloudflare/containers").Container>;
   TELEGRAM_BOT_TOKEN: string;
   LLM_OPENROUTER_BASEURL: string;
   LLM_OPENROUTER_APIKEY: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/container/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,6 +32,19 @@ max_retries = 3
 [triggers]
 crons = ["0 * * * *"]
 
+[[containers]]
+class_name = "MatchContainer"
+image = "./Dockerfile"
+max_instances = 3
+
+[[durable_objects.bindings]]
+class_name = "MatchContainer"
+name = "MATCH_CONTAINER"
+
+[[migrations]]
+new_sqlite_classes = ["MatchContainer"]
+tag = "v2"
+
 [vars]
 LLM_OPENROUTER_BASEURL = "https://openrouter.ai/api/v1"
 LLM_OPENROUTER_MODEL = "gpt-4o-mini"


### PR DESCRIPTION
## Summary

Move the AI match agent execution from the standard Worker runtime into a **Cloudflare Container** (unbounded CPU time). The Worker continues to handle lightweight I/O (D1, Vectorize), while the container runs the compute-heavy agent with DeepSeek API.

## Architecture

```
Before:  Worker.queue() -> handleMatch -> runMatchAgent() (inline in Worker)
After:   Worker.queue() -> handleMatch -> callAgent() -> Container HTTP POST /match -> runMatchAgent()
```

- **Worker** (pre-processing): D1 queries, Vectorize, filter recent/unmatched jobs — lightweight I/O only
- **Container** (agent execution): `runMatchAgent` with `@ai-sdk/openai` + DeepSeek API — no CPU time limits

## Changes

| File | Type | Description |
|------|------|-------------|
| `Dockerfile` | new | Node.js 22 Alpine image, tsx runs TypeScript |
| `src/container/server.ts` | new | HTTP server: POST /match wraps runMatchAgent |
| `src/container/server.test.ts` | new | 5 integration tests: health, data forwarding, env vars, error handling |
| `src/jobs/agent_client.ts` | new | Worker-side container communication |
| `src/jobs/agent_client.test.ts` | new | 5 unit tests: env var injection, HTTP format, response parsing |
| `src/index.ts` | mod | + MatchContainer extends Container class |
| `src/jobs/match.ts` | mod | runMatchAgent(...) -> callAgent(env, resume, expectations, input) |
| `wrangler.toml` | mod | + [[containers]], DO binding, migration v2 |
| `tsconfig.json` | mod | exclude src/container/ (Node.js target) |
| `vitest.config.ts` | new | include excluded test dirs |
| `package.json` | mod | + @cloudflare/containers, tsx |

## Unchanged

- `src/lib/agent/match_agent.ts` — **zero changes** (still uses @ai-sdk/openai + DeepSeek)
- buildSystemPrompt, tool definitions, scoring logic — all unchanged
- Queue/cron/other job handlers — all unchanged

## Tests

32 passed, 5 failed (pre-existing notify mock issue, unrelated)
