### PR TITLE
fix: crawler location/salary displacement + enforce match score >= 6

### DIFF
--- a/src/jobs/match.test.ts
+++ b/src/jobs/match.test.ts
@@ -223,6 +223,29 @@ describe("handleMatch", () => {
     expect(mockCreateMatchJobIfNotExist).not.toHaveBeenCalled();
   });
 
+  it("filters out agent results with score below 6", async () => {
+    mockGetUsersWithResume.mockResolvedValue([userWithResume]);
+    mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);
+    mockQuerySimilar.mockResolvedValue([{ id: "job-1", score: 0.95 }, { id: "job-2", score: 0.85 }]);
+    mockGetJobDetailsByIds.mockResolvedValue([
+      { ...recentJob, id: "job-1" },
+      { ...recentJob, id: "job-2", title: "Job 2" },
+    ]);
+    mockGetExistingMatchedJobIds.mockResolvedValue([]);
+    mockCallAgent.mockResolvedValue([
+      { jobId: "job-1", jobTitle: "Job 1", jobLink: "https://example.com/job/1", matchScore: "3", reason: "Low" },
+      { jobId: "job-2", jobTitle: "Job 2", jobLink: "https://example.com/job/1", matchScore: "8", reason: "Good" },
+    ]);
+
+    await handleMatch(makeEnv(), 0);
+
+    expect(mockCreateMatchJobIfNotExist).toHaveBeenCalledTimes(1);
+    const storedMatches = mockCreateMatchJobIfNotExist.mock.calls[0][1];
+    expect(storedMatches).toHaveLength(1);
+    expect(storedMatches[0].jobId).toBe("job-2");
+    expect(storedMatches[0].matchScore).toBe("8");
+  });
+
   it("filters out already-matched jobs and only sends new ones to agent", async () => {
     mockGetUsersWithResume.mockResolvedValue([userWithResume]);
     mockGetVectorById.mockResolvedValue([0.1, 0.2, 0.3]);

--- a/src/jobs/match.ts
+++ b/src/jobs/match.ts
@@ -57,7 +57,12 @@ export async function handleMatch(env: Env, offset: number): Promise<void> {
   );
 
   if (parsed.length) {
-    await createMatchJobIfNotExist(env.DB, parsed.map((p) => ({ userId: user.id, jobId: p.jobId, notification: false, matchScore: p.matchScore, matchReason: p.reason })));
-    console.log(`[match] stored ${parsed.length} matches for user ${user.id}`);
+    const validMatches = parsed.filter((p) => Number(p.matchScore) >= 6);
+    if (validMatches.length) {
+      await createMatchJobIfNotExist(env.DB, validMatches.map((p) => ({ userId: user.id, jobId: p.jobId, notification: false, matchScore: p.matchScore, matchReason: p.reason })));
+      console.log(`[match] stored ${validMatches.length} matches for user ${user.id} (${parsed.length - validMatches.length} filtered low-score)`);
+    } else {
+      console.log(`[match] all ${parsed.length} results filtered (score < 6) for user ${user.id}`);
+    }
   }
 }

--- a/src/lib/agent/match_agent.test.ts
+++ b/src/lib/agent/match_agent.test.ts
@@ -68,6 +68,15 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("getPendingJobs");
     expect(prompt).toContain("submitEvaluation");
   });
+
+  it("includes REVIEW step at end of workflow", () => {
+    const prompt = buildSystemPrompt("Resume", "Expectations");
+
+    expect(prompt).toContain("REVIEW");
+    expect(prompt).toContain("score is < 6");
+    expect(prompt).toContain("violates a candidate expectation");
+    expect(prompt).toContain("you made a mistake");
+  });
 });
 
 describe("runMatchAgent", () => {
@@ -226,6 +235,71 @@ describe("runMatchAgent", () => {
     expect(callArgs.tools.getPendingJobs).toBeDefined();
     expect(callArgs.tools.submitEvaluation).toBeDefined();
     expect(callArgs.providerOptions.openai.reasoningEffort).toBe("high");
+  });
+
+  it("rejects evaluation for score below 6", async () => {
+    const jobs = makeJobs(1);
+
+    mockGenerateText.mockImplementation(async (params: any) => {
+      const { tools } = params;
+      const batch: any = await tools.getPendingJobs.execute({ batchSize: 1 });
+      expect(batch.done).toBe(false);
+
+      const result: any = await tools.submitEvaluation.execute({
+        jobId: batch.jobs[0].jobId,
+        matchScore: "3",
+        reason: "Not a good match",
+      });
+      expect(result.error).toContain("below threshold");
+      return { text: "Done." };
+    });
+
+    const result = await runMatchAgent(baseInput(jobs));
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("rejects evaluation for non-numeric score", async () => {
+    const jobs = makeJobs(1);
+
+    mockGenerateText.mockImplementation(async (params: any) => {
+      const { tools } = params;
+      const batch: any = await tools.getPendingJobs.execute({ batchSize: 1 });
+
+      const result: any = await tools.submitEvaluation.execute({
+        jobId: batch.jobs[0].jobId,
+        matchScore: "n/a",
+        reason: "Bad score",
+      });
+      expect(result.error).toContain("below threshold");
+      return { text: "Done." };
+    });
+
+    const result = await runMatchAgent(baseInput(jobs));
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("accepts evaluation for score exactly 6", async () => {
+    const jobs = makeJobs(1);
+
+    mockGenerateText.mockImplementation(async (params: any) => {
+      const { tools } = params;
+      const batch: any = await tools.getPendingJobs.execute({ batchSize: 1 });
+
+      const result: any = await tools.submitEvaluation.execute({
+        jobId: batch.jobs[0].jobId,
+        matchScore: "6",
+        reason: "Barely passes",
+      });
+      expect(result.ok).toBe(true);
+      return { text: "Done." };
+    });
+
+    const result = await runMatchAgent(baseInput(jobs));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].matchScore).toBe("6");
   });
 
   it("returns partial results when generateText throws mid-process", async () => {

--- a/src/lib/agent/match_agent.ts
+++ b/src/lib/agent/match_agent.ts
@@ -82,6 +82,10 @@ export async function runMatchAgent(input: RunMatchAgentInput): Promise<UserMatc
             if (results.has(jobId)) {
               return { error: `Job ${jobId} was already evaluated.` };
             }
+            const score = Number(matchScore);
+            if (isNaN(score) || score < 6) {
+              return { error: `Score ${matchScore} is below threshold 6. Do not submit.` };
+            }
             results.set(jobId, { matchScore, reason });
             return { ok: true, totalEvaluated: results.size };
           },
@@ -147,5 +151,9 @@ ${expectationsHeader}
    c. **SUBMIT**: Only call submitEvaluation if score >= 6. Include a concise one-sentence reason.
 
 3. Call getPendingJobs again. Repeat until all jobs are evaluated.
-4. When all jobs are done, respond briefly.`;
+4. **REVIEW**: After all jobs are evaluated, review every submitted evaluation:
+   - If any job's score is < 6, you made a mistake — that job should NOT have been submitted.
+   - If any job violates a candidate expectation (e.g. wrong location, wrong job type), you made a mistake — it should NOT have been submitted.
+   - If you find mistakes, admit them and stop; do NOT submit further.
+5. When all done and verified, respond briefly.`;
 }

--- a/src/lib/crawler/__fixtures__/remoteok_test.html
+++ b/src/lib/crawler/__fixtures__/remoteok_test.html
@@ -1,0 +1,588 @@
+<tr data-offset="2" data-slug="remote-builder-chief-consultran-1132898" data-url="/remote-jobs/remote-builder-chief-consultran-1132898" data-epoch="1780689795" data-search="Consultran Builder Chief [" dev"]"="" data-company="Consultran" data-stack="" id="job-1132898" data-id="1132898" data-href="/remote-jobs/remote-builder-chief-consultran-1132898" class="job job-1132898 verified new    sticky    ==  highlighted  												" title="">
+						
+							<td class="image has-logo" style="">
+
+															<script type="application/ld+json">
+									{"@context":"http://schema.org","@type":"JobPosting","datePosted":"2026-06-05T20:03:15+00:00",
+									"description":"<h2>The Mission<\/h2><p>We are a trucking compliance business started in 1973. In the last 4 years we\u2019ve successfully transitioned from DOS systems and dot matrix printers to streamlined processes and web-based systems using contract developers and our own technical abilities. About 18 months ago, the owner started vibing with Replit Agent and Claude Code to ship internal tools, integrations, and web applications across our brands. While that\u2019s been fruitful as a proof-of-concept, the business owner is currently the primary builder, which is a terrible spot for a business owner to be.<\/p><p>We are looking for our first technical hire. A senior-level Full-Stack Developer who wants to get into the weeds and ship some cool internal systems and external services. We need a \"Builder-in-Chief\" to own the entire product lifecycle. You\u2019ll embed with the client service team to identify friction points, help design the solution, and direct AI agents to execute the build. We\u2019ll make sure y\n Apply now and work remotely at Consultran",
+																				"jobBenefits":["401k","paid_time_off","pension_matching","learning_budget","home_office_budget","no_monitoring"],
+																				"baseSalary":{"@type": "MonetaryAmount","currency": "USD","value": {"@type": "QuantitativeValue","minValue":80000,"maxValue":120000,"unitText": "YEAR"}},"employmentType":"FULL_TIME","directApply":false,"industry":"Startups",
+										"jobLocationType":"TELECOMMUTE",
+
+										
+											"jobLocation":[
+												{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"United States","addressRegion":"Anywhere","streetAddress":"Anywhere","postalCode":"Anywhere","addressLocality":"Anywhere"}}
+											],
+											"applicantLocationRequirements":[
+											{"@type":"Country","name":"United States"}										],
+										
+
+
+									"title":"Builder Chief","image":"https:\/\/r2.remoteok.com\/jobs\/40fe7eaa8aadf82df9ed607de4dd1ee21780689795.png","occupationalCategory":"Builder Chief","workHours":"Flexible","validThrough":"2026-09-03T20:03:15+00:00","hiringOrganization":{"@type":"Organization","name":"Consultran","url":"https:\/\/remoteok.com\/consultran","sameAs":"https:\/\/remoteok.com\/consultran","logo":{"@type":"ImageObject","url":"https:\/\/r2.remoteok.com\/jobs\/40fe7eaa8aadf82df9ed607de4dd1ee21780689795.png"}}}
+								</script>
+															<a alt="Consultran" class="preventLink" href="/remote-jobs/remote-builder-chief-consultran-1132898">
+									<img onerror="this.onerror=null;this.src='data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';" alt="Consultran" data-z="1" data-extension="png" itemprop="image" class="logo lazyload lazy" src="/assets/pixel.gif" data-src="https://resizeapi.com/resize-cgi/image/format=auto,fit=contain,width=100,height=100,quality=50/https://r2.remoteok.com/jobs/40fe7eaa8aadf82df9ed607de4dd1ee21780689795.png">
+								</a>
+													</td>
+							<td class="company position company_and_position" style="">
+
+							<a itemprop="url" class="preventLink" href="/remote-jobs/remote-builder-chief-consultran-1132898">
+								<h2 itemprop="title">
+									Builder Chief
+									
+								</h2>
+								 
+								
+							</a>
+							 <span class="verified tooltip" title="Verified listing: this job is posted from a verified source and is trustworthy">verified</span><br>
+							<span itemprop="hiringOrganization" itemscope="" itemtype="http://schema.org/Organization" class="companyLink" href="/consultran">
+																											<h3 itemprop="name">
+											Consultran										</h3>
+									
+									&nbsp;<img style="position:relative;top:2px;" alt="This job has just been posted and is fresh off the press" src="/assets/new2x.gif" width="30" height="14" class="tooltip" title="This job has just been posted and is fresh off the press">							</span><br><div class="location tooltip" title="This job is available for remote workers from United States. Click to see more remote jobs in United States"><a href="/remote-jobs-in-united-states">🇺🇸 United States</a></div><div class="salary">💰 $80k - $120k</div>						</td>
+						<td class="tags" style="">
+																								<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-dev-jobs" aria-label="Remote Developer Jobs" alt="Remote Developer Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Developer											</h3>
+										</div>									</a>
+														</td>
+						<td class="time" style="">
+							<time datetime="2026-06-05T20:03:15+00:00">
+																	<img src="/assets/paper-clip.svg" class="paper-clip">
+									10h															</time>
+						</td>
+						<td class="source" style="">
+															<a rel="noindex nofollow" class="no-border tooltip" target="_blank" href="/l/1132898">
+									<div target="_blank" class="apply_button no-logo" style="color:">
+										<p>
+											Apply
+										</p>
+																			</div>
+								</a>
+													</td>
+					</tr>
+<tr class="expand expand-1132898  " data-id="1132898">
+						<td colspan="999" class="heading">
+							<div class="expandContents" style="">
+
+							
+								<div class="description" itemprop="description">
+
+																														<div class="company_profile " style="">
+																																							<a class="no-border" href="/consultran">
+															<img alt="Consultran" class="logo lazyload" src="/assets/pixel.gif" data-src="https://resizeapi.com/resize-cgi/image/format=auto,fit=contain,width=300,height=300,quality=80/https://r2.remoteok.com/jobs/40fe7eaa8aadf82df9ed607de4dd1ee21780689795.png">
+														</a>
+																									
+												<a class="no-border" href="/consultran">
+													<h2>
+														Consultran													</h2>
+												</a>
+
+																									<p>
+														<a style="" rel="nofollow noopener" href="https://consultran.com">
+															consultran.com														</a>
+													</p>
+												
+
+																									<a target="_blank" class="button action-apply" data-job-id="1132898" href="/l/1132898" style="">
+														Apply now
+													</a>
+												
+												
+												
+												<p>
+													<strong>
+														Share this job:
+													</strong>
+
+													
+													<input readonly="" class="share-job-copy-paste" type="text" value="https://remoteok.com/remote-jobs/remote-builder-chief-consultran-1132898?ref=sh" style="">
+																											<br>
+														<span style="font-size:12px;margin-top:-7px;display:block;">Get a <a style="" href="https://rok.co/hire-remotely">rok.co</a> short link</span>
+																									</p>
+
+
+
+
+											
+																							</div>
+																			
+					
+
+									
+									
+																			<div style="text-align:left;font-size:32px;">
+											<span style="font-weight: 400;">Consultran is hiring a </span><br>
+											<h1 style="font-size:32px;">Remote Builder Chief</h1>
+										</div>
+									
+									<div class="html"><h2>The Mission</h2><p>We are a trucking compliance business started in 1973. In the last 4 years we’ve successfully transitioned from DOS systems and dot matrix printers to streamlined processes and web-based systems using contract developers and our own technical abilities. About 18 months ago, the owner started vibing with Replit Agent and Claude Code to ship internal tools, integrations, and web applications across our brands. While that’s been fruitful as a proof-of-concept, the business owner is currently the primary builder, which is a terrible spot for a business owner to be.</p><p>We are looking for our first technical hire. A senior-level Full-Stack Developer who wants to get into the weeds and ship some cool internal systems and external services. We need a "Builder-in-Chief" to own the entire product lifecycle. You’ll embed with the client service team to identify friction points, help design the solution, and direct AI agents to execute the build. We’ll make sure you have the tools and an environment to do your best work.</p><h2>The Stack &amp; Your Technical Role</h2><p>You won't be writing every line of code by hand, but you must be a master of the craft to validate, refactor, and secure what the AI produces. Because of our “just go with it” strategy, our stack has gotten wide. We’d like you to help us shape the stack going forward using your expertise. Our ecosystem currently includes:</p><ul><li><strong>Core Apps</strong>: Ruby on Rails (our primary fuel tax app, FM22), Laravel (authority filings), and Express/React (Authority work order management).&nbsp;</li><li><strong>Data &amp; Infra</strong>: PostgreSQL, a variety of hosts (Render, DigitalOcean, etc), and various no-code/low-code integrations (Airtable, Zapier, Make).</li><li><strong>Agent Orchestration</strong>: You will leverage the 3C’s: Claude, Cursor, and Codex to ship features while maintaining high code quality through rigorous review.</li></ul><h2>Core Responsibilities</h2><ul><li><strong>Operational Deep-Dives</strong>: You won't be bogged down writing lengthy requirements documents; your focus is on understanding the work. You will embed with our compliance teams (IFTA reporting, IRP Renewals, FMCSA Operating Authority) to find the friction. That means faster, more informed building and ensures we ship the right, “wow” features for the team.</li><li><strong>Build with incremental ambition</strong>: We’re often better off with a shipped feature this week than we are waiting around for the perfect solution. Work with the team to find where it creates value and delight.</li><li><strong>System Design</strong>: Collaborate with our part-time architect to design robust data models, scalable approaches, and API integrations (e.g., integrating third-party ELD normalization platforms like Terminal).</li><li><strong>Design “Not-Too-Shabby” Frontends</strong>: It’s 2026, there’s no reason to ship an ugly UI or a poor user experience. Maybe the UI won’t win any awards for novelty, but it’ll be high on usability and will be easy on our middle-aged eyes.</li><li><strong>Testing &amp; Deployment</strong>: Own the testing suite. You are responsible for ensuring that AI-generated code is maintainable and solves the business problem before it hits production.</li><li><strong>Technical Documentation</strong>: Ensure we have high quality and current technical documentation so enhancements, fixes, and maintenance are efficient.&nbsp;</li></ul><h2>About You</h2><ul><li>You have a track record of shipping production-grade software (not just prototypes).</li><li>You would rather sit down and watch someone work than ask a series of academic questions</li><li>You’ve developed deep domain knowledge in the past</li><li>You are “stack-agnostic”. You should be comfortable moving between Rails, Laravel, and Python depending on the tool needed for the job, even if you have a preference for one over the other.</li><li>You have a tinkerer mindset and a bias toward shipping, but with the discipline to keep our core data safe.</li></ul><p><em>We're a small company building real systems that help keep thousands of trucks on the road every day. If you're the kind of person who's energized by ownership, solving problems, and seeing the direct impact of what you build, we'd like to hear from you.</em></p>																																				Please mention the word <strong>PROMISE</strong> when applying to show you read the job post completely (#RMTU3LjI1NC4xNTQuMjM4). This is a feature to avoid fake spam applicants. Companies can search these words to find applicants that read this and instantly see they're human.<br>
+														<br>																																				<h2>Salary and compensation</h2>
+													<br>
+																																								 $80,000 — $120,000/year
+																								<br>
+													<br>
+													<h2>Benefits</h2>
+																											<p>
+															💰 401(k)														</p>
+																												<p>
+															🏖 Paid time off														</p>
+																												<p>
+															💰 401k matching														</p>
+																												<p>
+															📚 Learning budget														</p>
+																												<p>
+															🖥 Home office budget														</p>
+																												<p>
+															👀 No monitoring system														</p>
+																																																	</div>
+								</div>
+								
+								<div style="clear:both"></div>
+
+								<div class="instructions">
+																														<div class="html"><h2>How do you apply?</h2>
+												<p>Visit <a href="builder-in-chief.consultran.com">our application form</a>.</p>											</div>
+																																																																				<a class="button action-apply apply_1132898" data-job-id="1132898" href="/l/1132898" target="_blank" rel="nofollow">
+												Apply for this job
+											</a>
+
+																																																																													</div>
+							</div>
+
+
+													</td>
+					</tr>
+<tr class="divider">
+						<td colspan="10"></td>
+					</tr>
+<tr data-offset="3" data-slug="remote-senior-software-engineer-stellar-ai-1128869" data-url="/remote-jobs/remote-senior-software-engineer-stellar-ai-1128869" data-epoch="1780444803" data-search="Stellar AI Senior Software Engineer {" 0":"dev","3":"train"}"="" data-company="Stellar AI" data-stack="" id="job-1128869" data-id="1128869" data-href="/remote-jobs/remote-senior-software-engineer-stellar-ai-1128869" class="job job-1128869      sticky bumped   ==  highlighted  												" title="">
+						
+							<td class="image has-logo" style="">
+
+															<script type="application/ld+json">
+									{"@context":"http://schema.org","@type":"JobPosting","datePosted":"2026-06-03T00:00:03+00:00",
+									"description":"<div class=\"job-preview__description\"><p><strong>Location<\/strong><\/p><p>Remote - open to candidates in North America, Europe, the UK, South America, Australia, and New Zealand.<\/p><p><br \/><\/p><p><strong>About the Role<\/strong><\/p><p>Stellar AI is seeking experienced Software Engineers to contribute to projects across a wide range of technologies and programming languages, including JavaScript, Python, Go, C++, Ruby, and more.<\/p><p>This is an open-ended contract opportunity, structured around project-based work with no set schedules or minimum time \/ task commitments. Contributors who work with us decide which available projects they\u2019d like to work on, when they work, and how much they contribute, which makes it an excellent option for those seeking flexible and high-impact work.<\/p><p>In this role, you will help advance AI research by understanding complex systems, exploring large codebases, and developing approaches to verify the correctness of software behavior.<\/p><p><br \/><\/p>\n Apply now and work remotely at Stellar AI",
+																			"baseSalary":{"@type": "MonetaryAmount","currency": "USD","value": {"@type": "QuantitativeValue","minValue":90000,"maxValue":130000,"unitText": "YEAR"}},"employmentType":"CONTRACTOR","directApply":false,"industry":"Startups",
+										"jobLocationType":"TELECOMMUTE",
+
+										
+											"jobLocation":[
+												{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"United Kingdom","addressRegion":"Anywhere","streetAddress":"Anywhere","postalCode":"Anywhere","addressLocality":"Anywhere"}},{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"Australia","addressRegion":"Anywhere","streetAddress":"Anywhere","postalCode":"Anywhere","addressLocality":"Anywhere"}},{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"New Zealand","addressRegion":"Anywhere","streetAddress":"Anywhere","postalCode":"Anywhere","addressLocality":"Anywhere"}}
+											],
+											"applicantLocationRequirements":[
+											{"@type":"Country","name":"United Kingdom"}{"@type":"Country","name":"Australia"}{"@type":"Country","name":"New Zealand"}										],
+										
+
+
+									"title":"Senior Software Engineer","image":"https:\/\/r2.remoteok.com\/jobs\/6fc36a5296bd74a094d88bef3f1ee7b31762362696.png","occupationalCategory":"Senior Software Engineer","workHours":"Flexible","validThrough":"2026-09-01T00:00:03+00:00","hiringOrganization":{"@type":"Organization","name":"Stellar AI","url":"https:\/\/remoteok.com\/stellar-ai","sameAs":"https:\/\/remoteok.com\/stellar-ai","logo":{"@type":"ImageObject","url":"https:\/\/r2.remoteok.com\/jobs\/6fc36a5296bd74a094d88bef3f1ee7b31762362696.png"}}}
+								</script>
+															<a alt="Stellar AI" class="preventLink" href="/remote-jobs/remote-senior-software-engineer-stellar-ai-1128869">
+									<img onerror="this.onerror=null;this.src='data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';" alt="Stellar AI" data-z="2" data-extension="png" itemprop="image" class="logo lazyload lazy" src="/assets/pixel.gif" data-src="https://resizeapi.com/resize-cgi/image/format=auto,fit=contain,width=100,height=100,quality=50/https://r2.remoteok.com/jobs/6fc36a5296bd74a094d88bef3f1ee7b31762362696.png">
+								</a>
+													</td>
+							<td class="company position company_and_position" style="">
+
+							<a itemprop="url" class="preventLink" href="/remote-jobs/remote-senior-software-engineer-stellar-ai-1128869">
+								<h2 itemprop="title">
+									Senior Software Engineer
+									
+								</h2>
+								 
+								
+							</a>
+							 <span class="original tooltip" style="vertical-align:middle" title="This post was bumped by its poster 3 days ago">🎈</span><br>
+							<span itemprop="hiringOrganization" itemscope="" itemtype="http://schema.org/Organization" class="companyLink" href="/stellar-ai">
+																											<h3 itemprop="name">
+											Stellar AI										</h3>
+									
+																</span><br><div class="location">🇪🇺 Europe</div><div class="location">🌎 North America</div><div class="location tooltip" title="This job is available for remote workers from United Kingdom. Click to see more remote jobs in United Kingdom"><a href="/remote-jobs-in-united-kingdom">🇬🇧 United Kingdom</a></div><div class="location tooltip" title="This job is available for remote workers from Australia. Click to see more remote jobs in Australia"><a href="/remote-jobs-in-australia">🇦🇺 Australia</a></div><div class="location tooltip" title="This job is available for remote workers from New Zealand. Click to see more remote jobs in New Zealand"><a href="/remote-jobs-in-new-zealand">🇳🇿 New Zealand</a></div><div class="salary">💰 $90k - $130k</div><div class="location">⏰ Contractor</div>						</td>
+						<td class="tags" style="">
+																								<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-dev-jobs" aria-label="Remote Developer Jobs" alt="Remote Developer Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Developer											</h3>
+										</div>&nbsp;									</a>
+																									<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-train-jobs" aria-label="Remote Train Jobs" alt="Remote Train Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Train											</h3>
+										</div>									</a>
+														</td>
+						<td class="time" style="">
+							<time datetime="2026-06-03T00:00:03+00:00">
+																	<img src="/assets/paper-clip.svg" class="paper-clip">
+									3d															</time>
+						</td>
+						<td class="source" style="">
+															<a rel="noindex nofollow" class="no-border tooltip" target="_blank" href="/l/1128869">
+									<div target="_blank" class="apply_button no-logo" style="color:">
+										<p>
+											Apply
+										</p>
+																			</div>
+								</a>
+													</td>
+					</tr>
+<tr class="expand expand-1128869  " data-id="1128869">
+						<td colspan="999" class="heading">
+							<div class="expandContents" style="">
+
+							
+								<div class="description" itemprop="description">
+
+																														<div class="company_profile " style="">
+																																							<a class="no-border" href="/stellar-ai">
+															<img alt="Stellar AI" class="logo lazyload" src="/assets/pixel.gif" data-src="https://resizeapi.com/resize-cgi/image/format=auto,fit=contain,width=300,height=300,quality=80/https://r2.remoteok.com/jobs/6fc36a5296bd74a094d88bef3f1ee7b31762362696.png">
+														</a>
+																									
+												<a class="no-border" href="/stellar-ai">
+													<h2>
+														Stellar AI													</h2>
+												</a>
+
+												
+
+																									<a target="_blank" class="button action-apply" data-job-id="1128869" href="/l/1128869" style="">
+														Apply now
+													</a>
+												
+												
+												
+												<p>
+													<strong>
+														Share this job:
+													</strong>
+
+													
+													<input readonly="" class="share-job-copy-paste" type="text" value="https://remoteok.com/remote-jobs/remote-senior-software-engineer-stellar-ai-1128869?ref=sh" style="">
+																											<br>
+														<span style="font-size:12px;margin-top:-7px;display:block;">Get a <a style="" href="https://rok.co/hire-remotely">rok.co</a> short link</span>
+																									</p>
+
+
+
+
+											
+																							</div>
+																			
+					
+
+									
+									
+																			<div style="text-align:left;font-size:32px;">
+											<span style="font-weight: 400;">Stellar AI is hiring a </span><br>
+											<h1 style="font-size:32px;">Remote Senior Software Engineer</h1>
+										</div>
+									
+									<div class="html"><div class="job-preview__description"><p><strong>Location</strong></p><p>Remote - open to candidates in North America, Europe, the UK, South America, Australia, and New Zealand.</p><p><br></p><p><strong>About the Role</strong></p><p>Stellar AI is seeking experienced Software Engineers to contribute to projects across a wide range of technologies and programming languages, including JavaScript, Python, Go, C++, Ruby, and more.</p><p>This is an open-ended contract opportunity, structured around project-based work with no set schedules or minimum time / task commitments. Contributors who work with us decide which available projects they’d like to work on, when they work, and how much they contribute, which makes it an excellent option for those seeking flexible and high-impact work.</p><p>In this role, you will help advance AI research by understanding complex systems, exploring large codebases, and developing approaches to verify the correctness of software behavior.</p><p><br></p><p><strong>Compensation</strong></p><ul><li>$70 per hour after passing the qualification</li></ul><p><strong>Responsibilities</strong></p><ul><li>Rapidly build context in large, multi-module codebases</li><li>Analyze feature implementations for correctness and edge cases</li><li>Produce clear, structured documentation of findings and ratios</li></ul><p><strong>Requirement</strong></p><ul><li>Bachelor's degree in Computer Science or a related field</li><li>At least 2 years of experience as a Software Engineer</li><li>Excellent written communication skills</li><li>Ability to clearly explain complex technical concepts</li></ul><p><br></p><p><strong>About Stellar AI</strong></p><p>We offer flexible, project-based work in data annotation and AI training. Our platform is designed for self-service. You can control your workflow, access resources as needed, and build valuable experience in the growing AI industry at your own pace.</p><p>Whether you're seeking supplemental income, hands-on experience with AI, or engaging challenges in a fast-growing field, Stellar gives you the flexibility to meaningfully contribute to creating the next generation of AI technology on your own terms.</p></div>																																				Please mention the word <strong>ACHIEVIBLE</strong> when applying to show you read the job post completely (#RMTU3LjI1NC4xNTQuMjM4). This is a feature to avoid fake spam applicants. Companies can search these words to find applicants that read this and instantly see they're human.<br>
+														<br>																																				<h2>Salary and compensation</h2>
+													<br>
+																																								 $90,000 — $130,000/year
+																																															</div>
+								</div>
+								
+								<div style="clear:both"></div>
+
+								<div class="instructions">
+																														<div class="html"><h2>How do you apply?</h2>
+												<p><br></p>											</div>
+																																																																				<a class="button action-apply apply_1128869" data-job-id="1128869" href="/l/1128869" target="_blank" rel="nofollow">
+												Apply for this job
+											</a>
+
+																																																																													</div>
+							</div>
+
+
+													</td>
+					</tr>
+<tr class="divider">
+						<td colspan="10"></td>
+					</tr>
+<tr data-offset="4" data-slug="remote-entry-level-junior-trader-infiniti-group-1132574" data-url="/remote-jobs/remote-entry-level-junior-trader-infiniti-group-1132574" data-epoch="1780127413" data-search="Infiniti Group Entry Level Junior Trader {" 0":"other","1":"finance","3":"analyst"}"="" data-company="Infiniti Group" data-stack="" id="job-1132574" data-id="1132574" data-href="/remote-jobs/remote-entry-level-junior-trader-infiniti-group-1132574" class="job job-1132574      sticky    ==  highlighted  												" title="">
+						
+							<td class="image " style="">
+
+															<script type="application/ld+json">
+									{"@context":"http://schema.org","@type":"JobPosting","datePosted":"2026-05-30T07:50:13+00:00",
+									"description":"<div class=\"vacancy-intro reveal reveal-delay-2 is-visible\"><p>Infiniti Group operates at the crossroads of digital assets, analytical market research, and algorithm-informed trading methods. We are dedicated to building a team of motivated beginners who want hands-on exposure to financial markets and real trading situations.<\/p><p>We are looking for a\u00a0<strong>Junior Crypto Trader<\/strong>\u00a0\u2014 a role designed for those at the very start of their professional journey. If you're interested in reading market trends, executing trades, and working with data to inform your decisions, this is a great fit.<\/p><p>You will trade independently but with structured oversight and regular feedback from experienced traders. There are no strict performance targets. Our focus is on developing your practical trading abilities in live crypto markets. No previous work experience is needed \u2014 we provide complete training.<\/p><\/div><div class=\"vacancy-block reveal reveal-delay-3 is-visible\"><h3>Key Respon\n Apply now and work remotely at Infiniti Group",
+																				"jobBenefits":["unlimited_vacation","4_day_workweek","pay_in_crypto","profit_sharing","no_politics"],
+																				"baseSalary":{"@type": "MonetaryAmount","currency": "USD","value": {"@type": "QuantitativeValue","minValue":50000,"maxValue":60000,"unitText": "YEAR"}},"employmentType":"PART_TIME","directApply":false,"industry":"Startups",
+										"jobLocationType":"TELECOMMUTE",
+
+																					"applicantLocationRequirements":[{"@type":"Country","name":"Anywhere"}],
+											"jobLocation":[{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"Anywhere","addressRegion":"Anywhere","streetAddress":"Anywhere","postalCode":"Anywhere","addressLocality":"Anywhere"}}],
+										
+
+
+									"title":"Entry Level Junior Trader","occupationalCategory":"Entry Level Junior Trader","workHours":"Flexible","validThrough":"2026-08-28T07:50:13+00:00","hiringOrganization":{"@type":"Organization","name":"Infiniti Group","url":"https:\/\/remoteok.com\/infiniti-group","sameAs":"https:\/\/remoteok.com\/infiniti-group"}}
+								</script>
+															<a class="preventLink" href="/remote-jobs/remote-entry-level-junior-trader-infiniti-group-1132574">
+									<div data-z="3" class="logo initials">
+										<p>
+											IG										</p>
+									</div>
+								</a>
+													</td>
+							<td class="company position company_and_position" style="">
+
+							<a itemprop="url" class="preventLink" href="/remote-jobs/remote-entry-level-junior-trader-infiniti-group-1132574">
+								<h2 itemprop="title">
+									Entry Level Junior Trader
+									
+								</h2>
+								 
+								
+							</a>
+							<br>
+							<span itemprop="hiringOrganization" itemscope="" itemtype="http://schema.org/Organization" class="companyLink" href="/infiniti-group">
+																											<h3 itemprop="name">
+											Infiniti Group										</h3>
+									
+																</span><br><div class="location">🌏 Worldwide</div><div class="salary">💰 $50k - $60k</div><div class="location">⏰ Part time</div>						</td>
+						<td class="tags" style="">
+																								<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-other-jobs" aria-label="Remote Other Jobs" alt="Remote Other Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Other											</h3>
+										</div>&nbsp;									</a>
+																									<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-finance-jobs" aria-label="Remote Finance Jobs" alt="Remote Finance Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Finance											</h3>
+										</div>&nbsp;									</a>
+																									<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-analyst-jobs" aria-label="Remote Analyst Jobs" alt="Remote Analyst Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Analyst											</h3>
+										</div>									</a>
+														</td>
+						<td class="time" style="">
+							<time datetime="2026-05-30T07:50:13+00:00">
+																	<img src="/assets/paper-clip.svg" class="paper-clip">
+									7d															</time>
+						</td>
+						<td class="source" style="">
+															<a rel="noindex nofollow" class="no-border tooltip" target="_blank" href="/l/1132574">
+									<div target="_blank" class="apply_button no-logo" style="color:">
+										<p>
+											Apply
+										</p>
+																			</div>
+								</a>
+													</td>
+					</tr>
+<tr class="expand expand-1132574  " data-id="1132574">
+						<td colspan="999" class="heading">
+							<div class="expandContents" style="">
+
+							
+								<div class="description" itemprop="description">
+
+																														<div class="company_profile " style="">
+																																					
+												<a class="no-border" href="/infiniti-group">
+													<h2>
+														Infiniti Group													</h2>
+												</a>
+
+												
+
+																									<a target="_blank" class="button action-apply" data-job-id="1132574" href="/l/1132574" style="">
+														Apply now
+													</a>
+												
+												
+												
+												<p>
+													<strong>
+														Share this job:
+													</strong>
+
+																											<a target="_blank" href="https://rok.co/zn" class="qr_code qr_code_1132574"></a>
+														<script class="qr_code_script">
+															$(function() {
+																new QRCode($('.qr_code_1132574')[0], {
+																	text: 'https://rok.co/zn?ref=qr',
+																	width: 1000,
+																	height: 1000,
+																																			colorDark : "#000000",
+																																		colorLight : "#ffffff",
+																	correctLevel : QRCode.CorrectLevel.H
+																});
+															});
+														</script>
+													
+													<input readonly="" class="share-job-copy-paste" type="text" value="rok.co/zn" style="">
+																									</p>
+
+
+
+
+											
+																							</div>
+																			
+					
+
+									
+									
+																			<div style="text-align:left;font-size:32px;">
+											<span style="font-weight: 400;">Infiniti Group is hiring a </span><br>
+											<h1 style="font-size:32px;">Remote Entry Level Junior Trader</h1>
+										</div>
+									
+									<div class="html"><div class="vacancy-intro reveal reveal-delay-2 is-visible"><p>Infiniti Group operates at the crossroads of digital assets, analytical market research, and algorithm-informed trading methods. We are dedicated to building a team of motivated beginners who want hands-on exposure to financial markets and real trading situations.</p><p>We are looking for a&nbsp;<strong>Junior Crypto Trader</strong>&nbsp;— a role designed for those at the very start of their professional journey. If you're interested in reading market trends, executing trades, and working with data to inform your decisions, this is a great fit.</p><p>You will trade independently but with structured oversight and regular feedback from experienced traders. There are no strict performance targets. Our focus is on developing your practical trading abilities in live crypto markets. No previous work experience is needed — we provide complete training.</p></div><div class="vacancy-block reveal reveal-delay-3 is-visible"><h3>Key Responsibilities</h3><ul><li>Place buy and sell orders in cryptocurrency markets while following risk rules and basic strategies.</li><li>Watch real-time price changes, trading volumes, and order book movements.</li><li>Use charts, technical indicators, and market signals to guide trade entries and exits.</li><li>Keep track of active positions and assess potential gains or losses.</li><li>Follow crypto news and understand how events may affect prices.</li><li>Work with industry-standard trading interfaces and analytics dashboards.</li><li>Review your own trading results regularly to identify strengths and areas to improve.</li><li>Build a deeper understanding of market behavior and trading techniques over time.</li></ul></div><div class="vacancy-block reveal reveal-delay-4 is-visible"><h3>What We Offer</h3><ul><li>A chance to grow inside an international company with a global outlook.</li><li>100% remote work — you can operate from any location.</li><li>Flexible hours and adjustable workload.</li><li>Access to professional-grade trading tools and live market data.</li><li>Use of advanced analytics and reporting systems.</li><li>A clear roadmap for professional growth with increasing responsibility over time.</li><li>Ongoing help and feedback from seasoned market practitioners.</li><li>Hands-on training on professional trading platforms, guided by experienced mentors.</li></ul></div><div class="vacancy-block reveal reveal-delay-5 is-visible"><h3>Requirements</h3><ul><li>Basic computer literacy (using browsers, platforms, hotkeys).</li><li>Stable internet connection and a laptop or PC.</li><li>English at intermediate level or higher (to understand news and interface).</li><li>Ability to focus during market hours (flexible, but attentive).</li><li>Willingness to learn and ask questions.</li></ul></div>																																				Please mention the word <strong>ELAN</strong> when applying to show you read the job post completely (#RMTU3LjI1NC4xNTQuMjM4). This is a feature to avoid fake spam applicants. Companies can search these words to find applicants that read this and instantly see they're human.<br>
+														<br>																																				<h2>Salary and compensation</h2>
+													<br>
+																																								 $50,000 — $60,000/year
+																								<br>
+													<br>
+													<h2>Benefits</h2>
+																											<p>
+															🏖 Unlimited vacation														</p>
+																												<p>
+															📆 4 day workweek														</p>
+																												<p>
+															🥧 Pay in crypto														</p>
+																												<p>
+															💰 Profit sharing														</p>
+																												<p>
+															🚫 No politics at work														</p>
+																																																	</div>
+								</div>
+								
+								<div style="clear:both"></div>
+
+								<div class="instructions">
+																														<div class="html"><h2>How do you apply?</h2>
+												<p><a href="https://infinitiownerclub.com/work/remoteok">https://infinitiownerclub.com/work/remoteok</a></p>											</div>
+																																																																				<a class="button action-apply apply_1132574" data-job-id="1132574" href="/l/1132574" target="_blank" rel="nofollow">
+												Apply for this job
+											</a>
+
+																							<div style="font-size:12px;margin-top:-14px;font-weight:bold;">
+													or email to info@infinitiownerclub.com												</div>
+																																																																													</div>
+							</div>
+
+
+													</td>
+					</tr>
+<tr class="divider">
+						<td colspan="10"></td>
+					</tr>
+<tr data-offset="5" data-slug="remote-sourcing-specialist-theoria-medical-1132920" data-url="/remote-jobs/remote-sourcing-specialist-theoria-medical-1132920" data-epoch="1780704073" data-search="Theoria Medical Sourcing Specialist [" sys="" admin","recruiter","medical","non="" tech"]"="" data-company="Theoria Medical" data-stack="" id="job-1132920" data-id="1132920" data-href="/remote-jobs/remote-sourcing-specialist-theoria-medical-1132920" class="job job-1132920  new        ==    												" title="">
+						
+							<td class="image " style="">
+
+															<script type="application/ld+json">
+									{"@context":"http://schema.org","@type":"JobPosting","datePosted":"2026-06-06T00:01:13+00:00",
+									"description":"About Theoria\n\nTheoria Medical is leading the charge in healthcare innovation and quality of care - offering a unique blend of medical excellence and technological advancement, serving the post-acute sector. Our network includes multispecialty physician services covering skilled nursing facilities across the country.\n\nWe are currently seeking a Sourcing Specialist, to find providers serving local skilled nursing facilities within a close-knit, mission-driven care community.\n\nEssential Functions & Responsibilities\n\nCandidate Discovery\n\nDevelop and execute targeted sourcing strategies for active and passive candidates.\nUtilize recruitment tools on platforms like LinkedIn Recruiter, Greenhouse, Practice Match and Doc Caf\u00e9.\nConduct comprehensive market research to map talent pools and target competitive companies.\nCapitalizing on prior sourcing experience to add a creative flair to attract talent when needed. \nCraft high-converting, personalized outreach campaigns to engage \n Apply now and work remotely at Theoria Medical",
+																			"baseSalary":{"@type": "MonetaryAmount","currency": "USD","value": {"@type": "QuantitativeValue","minValue":80000,"maxValue":120000,"unitText": "YEAR"}},"employmentType":"FULL_TIME","directApply":false,"industry":"Startups",
+										"jobLocationType":"TELECOMMUTE",
+
+																					"applicantLocationRequirements":[{"@type":"Country","name":"Anywhere"}],
+											"jobLocation":[{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"Anywhere","addressRegion":"Anywhere","streetAddress":"Anywhere","postalCode":"Anywhere","addressLocality":"Anywhere"}}],
+										
+
+
+									"title":"Sourcing Specialist","occupationalCategory":"Sourcing Specialist","workHours":"Flexible","validThrough":"2026-09-04T00:01:13+00:00","hiringOrganization":{"@type":"Organization","name":"Theoria Medical","url":"https:\/\/remoteok.com\/theoria-medical","sameAs":"https:\/\/remoteok.com\/theoria-medical"}}
+								</script>
+															<a class="preventLink" href="/remote-jobs/remote-sourcing-specialist-theoria-medical-1132920">
+									<div data-z="4" class="logo initials">
+										<p>
+											TM										</p>
+									</div>
+								</a>
+													</td>
+							<td class="company position company_and_position" style="">
+
+							<a itemprop="url" class="preventLink" href="/remote-jobs/remote-sourcing-specialist-theoria-medical-1132920">
+								<h2 itemprop="title">
+									Sourcing Specialist
+									
+								</h2>
+								 
+								
+							</a>
+							<br>
+							<span itemprop="hiringOrganization" itemscope="" itemtype="http://schema.org/Organization" class="companyLink" href="/theoria-medical">
+																											<h3 itemprop="name">
+											Theoria Medical										</h3>
+									
+									&nbsp;<img style="position:relative;top:2px;" alt="This job has just been posted and is fresh off the press" src="/assets/new2x.gif" width="30" height="14" class="tooltip" title="This job has just been posted and is fresh off the press">							</span><br><div class="location">🌏 Worldwide</div><div class="location tooltip">💰 Upgrade to Premium to see salary</div>						</td>
+						<td class="tags" style="">
+																								<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-sys-admin-jobs" aria-label="Remote Sys Admin Jobs" alt="Remote Sys Admin Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Sys Admin											</h3>
+										</div>&nbsp;									</a>
+																									<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-recruiter-jobs" aria-label="Remote Recruiter Jobs" alt="Remote Recruiter Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Recruiter											</h3>
+										</div>&nbsp;									</a>
+																									<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-medical-jobs" aria-label="Remote Medical Jobs" alt="Remote Medical Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Medical											</h3>
+										</div>									</a>
+																									<a class="no-border tooltip-set action-add-tag" data-tooltip="Add  to filters" href="/remote-non-tech-jobs" aria-label="Remote Non Tech Jobs" alt="Remote Non Tech Jobs">
+										<div rel="follow" class="tag tag- action-add-tag" style="">
+											<h3>
+												Non Tech											</h3>
+										</div>									</a>
+														</td>
+						<td class="time" style="">
+							<time datetime="2026-06-06T00:01:13+00:00">
+																	6h															</time>
+						</td>
+						<td class="source" style="">
+															<a rel="noindex nofollow" class="no-border tooltip" target="_blank" href="/l/1132920">
+									<div target="_blank" class="apply_button no-logo" style="color:">
+										<p>
+											Apply
+										</p>
+																			</div>
+								</a>
+													</td>
+					</tr>
+<tr class="expand expand-1132920  " data-id="1132920">
+						<td colspan="999" class="heading">
+							<div class="expandContents" style="">
+
+							
+								<div class="description" itemprop="description">
+
+																												
+					
+
+									
+									
+																			<div style="text-align:left;font-size:32px;">
+											<span style="font-weight: 400;">Theoria Medical is hiring a </span><br>
+											<h1 style="font-size:32px;">Remote Sourcing Specialist</h1>
+										</div>
+									
+									<div class="markdown">About Theoria\n\nTheoria Medical is leading the charge in healthcare innovation and quality of care - offering a unique blend of medical excellence and technological advancement, serving the post-acute sector. Our network includes multispecialty physician services covering skilled nursing facilities across the country.\n\nWe are currently seeking a Sourcing Specialist, to find providers serving local skilled nursing facilities within a close-knit, mission-driven care community.\n\nEssential Functions &amp; Responsibilities\n\nCandidate Discovery\n\nDevelop and execute targeted sourcing strategies for active and passive candidates.\nUtilize recruitment tools on platforms like LinkedIn Recruiter, Greenhouse, Practice Match and Doc Café.\nConduct comprehensive market research to map talent pools and target competitive companies.\nCapitalizing on prior sourcing experience to add a creative flair to attract talent when needed. \nCraft high-converting, personalized outreach campaigns to engage cold leads.\nAct as the primary, high-charisma ambassador of our employer brand via written communications.\nFollow-ups with active and passive candidates.\nPopulate and organize Greenhouse (ATS).\nDeliver talent pipelines to champion company initiatives.\nSchedule interviews for the recruiters.\n\nCompensation and Benefits:\n\nPaid vacation and sick leaves\nCompetitive compensation package\nBenefits include: medical benefits, PTO, paid holidays\nOvertime available\n\nRequired Skills &amp; Qualifications\n\nExperience: 2–3 years of dedicated talent sourcing or full-cycle recruiting experience preferably in the healthcare industry.\nSystem Familiarity: Hands-on experience working inside mainstream ATS platform layouts (Greenhouse).\nCommunication: Exceptional writing skills tailored toward creating catchy, professional email and text messages.\nMindset: Highly resilient attitude paired with data-driven problem-solving habits.\n\nEmployee must be able to perform the essential functions of this p																																																																					\n\n#Location\nRemote<br>
+																							</div>
+								</div>
+								
+								<div style="clear:both"></div>
+
+								<div class="instructions">
+																																																										<a class="button action-apply apply_1132920" data-job-id="1132920" href="/l/1132920" target="_blank" rel="nofollow">
+												Apply for this job
+											</a>
+
+																																																																													</div>
+							</div>
+
+
+													</td>
+					</tr>
+<tr class="divider">
+						<td colspan="10"></td>
+					</tr>

--- a/src/lib/crawler/__fixtures__/weworkremotely_test.rss
+++ b/src/lib/crawler/__fixtures__/weworkremotely_test.rss
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <link>test</link>
+    <description>Test</description>
+    <item>
+      <media:content url="https://wwr-pro.s3.amazonaws.com/logos/0171/5443/logo.gif" type="image/png"/>
+      <title>Varicent: Support Engineer – SQL &amp; Web Applications (Remote - Mexico Only)</title>
+      <region>Anywhere in the World</region>
+      <country></country>
+      <state></state>
+      <skills>Adobe Creative Suite, Community Growth, Competitor Analysis, Architect, Architecture, Bug Tracking, Blog Writing,  Editing, Audio Editing, and Brand Identity Design</skills>
+      <category>Full-Stack Programming</category>
+      <type>Full-Time</type>
+      <description>&lt;img src="https://we-work-remotely.imgix.net/logos/0171/5443/logo.gif?ixlib=rails-4.0.0&amp;w=50&amp;h=50&amp;dpr=2&amp;fit=fill&amp;auto=compress" /&gt;
+
+&lt;p&gt;
+  &lt;strong&gt;Headquarters:&lt;/strong&gt; Tijuana, Mexico
+    &lt;br /&gt;&lt;strong&gt;URL:&lt;/strong&gt; &lt;a href="http://varicent.com"&gt;http://varicent.com&lt;/a&gt;
+&lt;/p&gt;
+
+&lt;div class="job__description body"&gt;&lt;div&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;
+&lt;div class="p-rich_text_section"&gt;At Varicent, we’re not just transforming the Sales Performance Management (SPM) market—we’re redefining how organizations achieve revenue success. Our cutting-edge SaaS solutions empower revenue leaders globally to design smarter go-to-market strategies, maximize seller performance, and unlock untapped potential. Varicent stands at the forefront of innovation, celebrated as a market leader in the&amp;nbsp;&lt;em&gt;2025 Forrester Wave Report for SPM&lt;/em&gt;,&amp;nbsp;&lt;em&gt;2023 Ventana Research Revenue Performance Management (RPM) Value Index&lt;/em&gt;,&amp;nbsp;&lt;em&gt;Gartner Peer Insights&lt;/em&gt;,&amp;nbsp;&lt;em&gt;2024 Gartner SPM Market Guide&lt;/em&gt;, and&amp;nbsp;&lt;em&gt;G2.&amp;nbsp;&lt;/em&gt;Our solutions are trusted by a diverse range of global industry leaders like T-Mobile, ServiceNow, Wawanesa Bank, Shaw Industries, Moody's, Stryker and hundreds more. Here’s why you’ll thrive at Varicent:&lt;/div&gt;
+&lt;ul class="p-rich_text_list p-rich_text_list__bullet p-rich_text_list--nested"&gt;
+&lt;li&gt;&lt;strong&gt;Innovate with Purpose: Build impactful solutions for customers worldwide.&lt;/strong&gt;&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Join Excellence: Work in a diverse, collaborative, and innovative team.&lt;/strong&gt;&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Shape the Future: Lead in redefining revenue optimization.&lt;/strong&gt;&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;Grow Together: Unlock your potential in a supportive environment.&lt;/strong&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;div class="p-rich_text_section"&gt;Join us at Varicent—where your talent and ambition meet limitless opportunities for success!&lt;/div&gt;&lt;/div&gt;&lt;div&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;THE OPPORTUNITY &lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;Our Technical Support Team serves as the frontline of customer success, specializing in providing expert assistance to users navigating our SaaS solutions. They troubleshoot technical challenges, answer complex queries, and ensure that customers can maximize the value of our products. Beyond solving immediate issues, the team collaborates closely with product and development teams to report bugs, contribute to product enhancements, and share insights into user experiences. Their ultimate goal is to deliver exceptional service, foster customer satisfaction, and enable seamless adoption of our technology across diverse use cases.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;THE TEAM&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;The Technical Analyst I works with clients to resolve issues, lead conversations and coordinate activities across departments,&lt;/span&gt;&lt;span&gt; and reproduces issues to &lt;/span&gt;&lt;span&gt;maintain high client satisfaction.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;As a&lt;/span&gt;&lt;strong&gt;&lt;span&gt; Technical Analyst&lt;/span&gt;&lt;/strong&gt;&lt;span&gt; you will have the opportunity to work side-by-side with some of the most experienced technology leaders for both on-premises and SaaS products to support our customers/business partners and connect with them by video conference, email and CRM and other state of the art communication methods. You will also be exposed to a variety of technologies and take responsibility for the creation of a positive customer experience.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;Technical Analysts are at the center of our after-sales value proposition to our clients, and you will lead conversations and coordinate activities with experts and leaders across departments and divisions in Varicent.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;WHAT YOU BRING&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span&gt;Technical Skills&lt;/span&gt;&lt;/strong&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;2+ Years of relevant technical experience.&amp;nbsp;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Proven experience working with SaaS platforms (mandatory)&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;&lt;span&gt;Familiar with relational databases concepts, both basic administration and SQL scripting. &lt;/span&gt;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;&lt;span&gt;Familiar with client server architecture. &lt;/span&gt;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Ability to communicate clearly (both verbally and in written form) technical instructions to people with limited experience. &lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;&lt;span&gt;Sharing best practices for the &lt;/span&gt;&lt;span&gt;utilization&lt;/span&gt;&lt;span&gt; and deployment of Varicent products. &lt;/span&gt;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;&lt;span&gt;Help customers maximize their product’s business value.&lt;/span&gt;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;&lt;span&gt;Troubleshooting experience for web-based applications.&amp;nbsp;&lt;/span&gt;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;Collaboration and Communication: &lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;CEFR B2 level English proficiency or higher is required.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Ability to work and collaborate effectively in cross-functional teams.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;WHAT YOU’LL DO &lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;Resolve technical problems by troubleshooting incidents, including but not limited to collecting detailed problem description, traces, log files, and replication.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Communicate progress of investigation with clients while ensuring all related records are properly updated in the CRM system.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Proficient in utilizing all support tools and processes to resolve cases.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Share best practices for the utilization and deployment of Varicent products.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Support KPI targets (SLA, QA, Resolution, etc.).&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Available for scheduled weekend coverage for on call rotation . &lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;1-3 MONTHS&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;Efficiently familiarize oneself with the organization's systems, processes, and team dynamics.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Establish a working knowledge of key technologies and tools relevant to the role.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Complete Training and start solving support cases.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;4-6 MONTHS&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;Demonstrate proficiency in using relevant analytical tools and technologies.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Be able to solve 90% of cases without need for assistance.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Actively contribute to team projects and initiatives.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;7 MONTHS &amp;amp; BEYOND&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;Be able to solve 99% of cases without assistance, help build knowledge for the rest of team.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Conduct in-depth analysis of complex technical issues and provide well-reasoned solutions.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Proactively anticipate and address potential challenges before they escalate.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Build and maintain positive relationships with key stakeholders.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;Note&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;Candidates selected for this position will be hired by Varicent’s designated professional employer organization. Your employment may be transferred to a local Varicent entity in the future. In such event, Varicent may recognize your seniority and provide you with comparable role, responsibilities and benefits.&amp;nbsp; We are excited to welcome you and support you throughout this journey!&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;This role requires employees to work within Eastern Standard Time (EST) business hours. While we are open to candidates from outside the EST time zone, please be prepared to adjust your working hours to align with this time zone. Flexibility will be essential to ensure seamless collaboration with the team and stakeholders.&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;This position is fully remote. We embrace a results-driven work culture, focusing on performance and collaboration over location. As part of our team, you’ll have the opportunity to build a work-life balance that suits you, while staying connected with a diverse, global team through virtual tools and regular online communication. Whether you're working from home or a co-working space we’re committed to supporting you with the resources and autonomy needed to succeed in a remote environment.&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;Benefits&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;span&gt;&lt;strong&gt;Market Leading &lt;/strong&gt;Compensation Package.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;&lt;strong&gt;Wellness Programs&amp;nbsp;&lt;/strong&gt;to Support Health and Wellbeing. &amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Working with the latest&lt;strong&gt; tools and technologies &lt;/strong&gt;in a fast-paced environment. &amp;nbsp;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Remote Work Flexibility.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Comprehensive Employee Insurance Coverage: Medical, Dental, Vision, Life Insurance. &lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Annual Time Off: Time off is provided in accordance with applicable legislative requirements. &lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Global Connected Culture: Hubs in Romania, UK, US, Canada.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Dynamic Work Culture: Thrive in our innovative and multicultural environment.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;span&gt;Grow with Us: Continuous development opportunities.&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;span&gt;Want to Learn More About Us? Check out these Resources Below:&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.varicent.com/blog?utm_source=Google&amp;amp;utm_campaign=DN_Google_US_Brand&amp;amp;utm_content=Brand_Product_Tour_Page_Fall+AO+Refreshct_Tour_Page_Always_On&amp;amp;utm_medium=paidsearch&amp;amp;_gl=1*qhz6pt*_up*MQ..&amp;amp;gclid=Cj0KCQjwtsy1BhD7ARIsAHOi4xbc72l3bTLx9rhjxbs2lsK9V7zbHda2nAeNVMaIchjVBLSiegt1Yc0aAl3WEALw_wcB"&gt;&lt;span&gt;&lt;span&gt;Varicent Blog&amp;nbsp;&lt;/span&gt;&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.varicent.com/careers-blog?utm_source=Google&amp;amp;utm_campaign=DN_Google_US_Brand&amp;amp;utm_content=Brand_Product_Tour_Page_Fall+AO+Refreshct_Tour_Page_Always_On&amp;amp;utm_medium=paidsearch&amp;amp;_gl=1*1vxffxk*_up*MQ..&amp;amp;gclid=Cj0KCQjwtsy1BhD7ARIsAHOi4xbc72l3bTLx9rhjxbs2lsK9V7zbHda2nAeNVMaIchjVBLSiegt1Yc0aAl3WEALw_wcB"&gt;&lt;span&gt;&lt;span&gt;Varicent Careers Blog &lt;/span&gt;&lt;/span&gt;&lt;/a&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.linkedin.com/company/varicent/"&gt;&lt;span&gt;&lt;span&gt;Varicent LinkedIn Page&lt;/span&gt;&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://x.com/i/flow/login?redirect_after_login=%2Fthisisvaricent"&gt;&lt;span&gt;&lt;span&gt;Varicent X Page&lt;/span&gt;&lt;/span&gt;&lt;/a&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.instagram.com/accounts/login/?next=https%3A%2F%2Fwww.instagram.com%2Fthisisvaricent%2F%3Fhl%3Den&amp;amp;is_from_rle"&gt;&lt;span&gt;&lt;span&gt;Varicent Instagram Page&lt;/span&gt;&lt;/span&gt;&lt;/a&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.facebook.com/varicent/"&gt;&lt;span&gt;&lt;span&gt;Varicent Facebook Page&lt;/span&gt;&lt;/span&gt;&lt;/a&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;span&gt;&amp;nbsp;&lt;/span&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;/div&gt;&lt;div&gt;&lt;p&gt;&lt;/p&gt;
+&lt;div&gt;Varicent is committed to creating a diverse environment and is proud to be an equal opportunity employer. All qualified applicants will receive consideration for employment without regard to race, color, religion, gender, gender identity or expression, sexual orientation, national origin, genetics, disability, age, or veteran status. If you require accommodation at any time during the recruitment process please email accomodations@varicent.com&lt;/div&gt;
+&lt;div&gt;&amp;nbsp;&lt;/div&gt;
+&lt;div&gt;Varicent is also committed to compliance with all fair employment practices regarding citizenship and immigration status. By applying for a position at Varicent and/or by using this portal, you declare and confirm that you have read and agree to our&lt;a class="postings-link" href="https://www.varicent.com/recruitment-portal-privacy-notice"&gt;&amp;nbsp;Job Applicant Privacy Notice&lt;/a&gt;&amp;nbsp;and that the information provided by you as part of your application is true and complete and includes no misrepresentation or material omission of fact&lt;/div&gt;
+&lt;p&gt;&lt;/p&gt;&lt;/div&gt;&lt;/div&gt;
+
+&lt;p&gt;&lt;strong&gt;To apply:&lt;/strong&gt; &lt;a href="https://weworkremotely.com/remote-jobs/varicent-support-engineer-sql-web-applications-remote-mexico-only"&gt;https://weworkremotely.com/remote-jobs/varicent-support-engineer-sql-web-applications-remote-mexico-only&lt;/a&gt;&lt;/p&gt;
+</description>
+      <pubDate>Fri, 05 Jun 2026 20:37:07 +0000</pubDate>
+      <expires_at>Sun, 05 Jul 2026 20:37:07 +0000</expires_at>
+      <guid>https://weworkremotely.com/remote-jobs/varicent-support-engineer-sql-web-applications-remote-mexico-only</guid>
+      <link>https://weworkremotely.com/remote-jobs/varicent-support-engineer-sql-web-applications-remote-mexico-only</link>
+    </item>
+    <item>
+      <title>Akamai: Senior Software Development Engineer in Test II - Automation</title>
+      <region>Anywhere in the World</region>
+      <country></country>
+      <state></state>
+      <skills>Adobe Creative Suite, CMS Development, Community Growth, Competitor Analysis, Architect, Architecture, Blog Writing,  Editing, Audio Editing, and Brand Identity Design</skills>
+      <category>Full-Stack Programming</category>
+      <type>Full-Time</type>
+      <description>
+
+&lt;p&gt;
+  &lt;strong&gt;Headquarters:&lt;/strong&gt; United States
+    &lt;br /&gt;&lt;strong&gt;URL:&lt;/strong&gt; &lt;a href="http://akamai.com"&gt;http://akamai.com&lt;/a&gt;
+&lt;/p&gt;
+
+&lt;div&gt;&lt;strong&gt;Description&lt;/strong&gt;&lt;br&gt;&lt;p&gt;&lt;strong&gt;Are you excited to work on innovative enterprise security products?&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Do you enjoy collaborating with developers and impacting products touching life online for millions of users billions times a day?&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Join Our Team&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;Our team operates within the Zero Trust Security Group, developing advanced security solutions for government and defense customers. We build and operate secure, mission-critical platforms in highly regulated environments. As part of a global team, we design/deploy cloud-native/edge solutions that integrate with tactical networks, enterprise systems, and partner technologies.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Partner with the best&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;As a Senior Software Engineer in Test II, you will develop, execute, and maintain test suites for our cloud services/web applications, focusing on FedRAMP standards. Working on top-notch network security projects with highly skilled colleagues, you will enjoy challenges in an exciting, dynamic learning environment.&lt;/p&gt;
+&lt;p&gt;As a Senior II Software Development Engineer in Test, you will be responsible for:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Providing high-quality test strategies using industry-standard tools and frameworks&lt;/li&gt;
+&lt;li&gt;Designing, maintaining, and executing automated test suites for our Zero Trust solution&lt;/li&gt;
+&lt;li&gt;Managing test executions, including application functionality, performance and security&lt;/li&gt;
+&lt;li&gt;Working closely with the development and product teams to understand project requirements and identify test scenarios for automation&lt;/li&gt;
+&lt;li&gt;Contributing to the enhancement of the automated testing infrastructure and integrate it into our CI/CD pipelines&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;strong&gt;Do what you love&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;To be successful in this role you will:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Have 8+ years as Automation Engineer experience and a degree in CS or related field&lt;/li&gt;
+&lt;li&gt;Have experience writing/maintaining tests using Python and spinning up environments using tools like K8s, Podman, VMware or other cloud platforms&lt;/li&gt;
+&lt;li&gt;Have hands-on experience with test automation frameworks and tools&lt;/li&gt;
+&lt;li&gt;Be proficient in writing and executing SQL queries for database validation&lt;/li&gt;
+&lt;li&gt;Have experience with version control systems (e.g., Git), continuous integration tools (e.g., Jenkins), and project management and tracking tools (e.g., JIRA)&lt;/li&gt;
+&lt;li&gt;Have experience developing/maintaining component and integration tests ensuring the seamless interaction and functionality of individual services within the larger system&lt;/li&gt;
+&lt;li&gt;Demonstrate understanding of containerization and orchestration technologies such as Docker and Kubernetes&lt;/li&gt;
+&lt;li&gt;Be eligible to obtain a Secret Security Clearance&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;strong&gt;Work in a way that works for you&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;FlexBase, Akamai's Global Flexible Working Program, is based on the principles that are helping us create the best workplace in the world. When our colleagues said that flexible working was important to them, we listened. We also know flexible working is important to many of the incredible people considering joining Akamai. FlexBase, gives 95% of employees the choice to work from their home, their office, or both (in the country advertised). This permanent workplace flexibility program is consistent and fair globally, to help us find incredible talent, virtually anywhere. We are happy to discuss working options for this role and encourage you to speak with your recruiter in more detail when you apply.&amp;nbsp;&lt;br&gt;&lt;br&gt;&lt;a href="https://www.akamai.com/careers"&gt;Learn&lt;/a&gt;&amp;nbsp;what makes Akamai a great place to work&lt;/p&gt;
+
+
+
+Connect with us on social and see what life at Akamai is like!
+&lt;a href="https://twitter.com/Akamai?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"&gt;&lt;/a&gt;&amp;nbsp;&lt;a href="https://www.facebook.com/akamaicareers/"&gt;&lt;/a&gt;&amp;nbsp;&lt;a href="https://www.linkedin.com/company/akamai-technologies/"&gt;&lt;/a&gt;&amp;nbsp;&lt;a href="https://www.instagram.com/akamaicareers/"&gt;&lt;/a&gt;&amp;nbsp;&lt;a href="https://www.akamai.com/blog?"&gt;&lt;/a&gt;&amp;nbsp;&lt;a href="https://www.youtube.com/playlist?list=PLYo5nh8xQFpnnPl17sQRURR9ugKL-KMRO"&gt;&lt;/a&gt;
+
+
+
+&lt;p&gt;&lt;strong&gt;We power and protect life online, by solving the toughest challenges, together.&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;At Akamai, we're curious, innovative, collaborative and tenacious. We celebrate diversity of thought and we hold an unwavering belief that we can make a meaningful difference. Our teams use their global perspectives to put customers at the forefront of everything they do, so if you are people-centric, you'll thrive here.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Working for you&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;At Akamai, we will provide you with opportunities to grow, flourish, and achieve great things. Our benefit options are designed to meet your individual needs for today and in the future. We provide benefits surrounding all aspects of your life:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Your health&lt;/li&gt;
+&lt;li&gt;Your finances&lt;/li&gt;
+&lt;li&gt;Your family&lt;/li&gt;
+&lt;li&gt;Your time at work&lt;/li&gt;
+&lt;li&gt;Your time pursuing other endeavors&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Our benefit plan options are designed to meet your individual needs and budget, both today and in the future.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;About us&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;Akamai powers and protects life online. Leading companies worldwide choose Akamai to build, deliver, and secure their digital experiences helping billions of people live, work, and play every day. With the world's most distributed compute platform from cloud to edge we make it easy for customers to develop and run applications, while we keep experiences closer to users and threats farther away.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Join us&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;Are you seeking an opportunity to make a real difference in a company with a global reach and exciting services and clients? Come join us and grow with a team of people who will energize and inspire you!&lt;br&gt;&lt;br&gt;
+  Akamai Technologies is an Affirmative Action, Equal Opportunity Employer that values the strength that diversity brings to the workplace. All qualified applicants will receive consideration for employment and will not be discriminated against on the basis of gender, gender identity, sexual orientation, race/ethnicity, protected veteran status, disability, or other protected group status.&lt;br&gt;&lt;br&gt;
+  If no date is displayed, applications are being accepted on an ongoing basis until the job is filled.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Compensation&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;Akamai is committed to fair and equitable compensation practices. For US based candidates only - the base salary for this position ranges from $146,400 - $263,600/year; a candidate’s salary is determined by various factors including, but not limited to, relevant work experience, skills, certifications and location. Compensation for candidates outside the US will vary. The compensation package may also include incentive compensation opportunities in the form of annual bonus or incentives, equity awards and an Employee Stock Purchase Plan (ESPP). Akamai provides industry-leading benefits including healthcare, 401K savings plan, company holidays, vacation (in the form of PTO), sick time, family friendly benefits including parental leave and an employee assistance program including a focus on mental and financial wellness; Eligibility requirements apply.&lt;/p&gt;&lt;br&gt;&lt;br&gt;&lt;br&gt;&lt;/div&gt;
+
+&lt;p&gt;&lt;strong&gt;To apply:&lt;/strong&gt; &lt;a href="https://weworkremotely.com/remote-jobs/akamai-senior-software-development-engineer-in-test-ii-automation"&gt;https://weworkremotely.com/remote-jobs/akamai-senior-software-development-engineer-in-test-ii-automation&lt;/a&gt;&lt;/p&gt;
+</description>
+      <pubDate>Fri, 05 Jun 2026 20:37:07 +0000</pubDate>
+      <expires_at>Sun, 05 Jul 2026 20:37:07 +0000</expires_at>
+      <guid>https://weworkremotely.com/remote-jobs/akamai-senior-software-development-engineer-in-test-ii-automation</guid>
+      <link>https://weworkremotely.com/remote-jobs/akamai-senior-software-development-engineer-in-test-ii-automation</link>
+    </item>
+    <item>
+      <media:content url="https://wwr-pro.s3.amazonaws.com/logos/0171/5442/logo.gif" type="image/png"/>
+      <title>AHU Technologies: Web Applications Developer - Sacramento, CA</title>
+      <region>Anywhere in the World</region>
+      <country></country>
+      <state></state>
+      <skills>Analytics, Cross-Browser Development, Google Analytics, Monitoring and Analytics, MySQL, PostgreSQL, NoSQL, PostgreeSQL, Cross-Selling, and Analytics Tools</skills>
+      <category>Full-Stack Programming</category>
+      <type>Full-Time</type>
+      <description>&lt;img src="https://we-work-remotely.imgix.net/logos/0171/5442/logo.gif?ixlib=rails-4.0.0&amp;w=50&amp;h=50&amp;dpr=2&amp;fit=fill&amp;auto=compress" /&gt;
+
+&lt;p&gt;
+  &lt;strong&gt;Headquarters:&lt;/strong&gt; Fully Remote - US
+    &lt;br /&gt;&lt;strong&gt;URL:&lt;/strong&gt; &lt;a href="http://ahutech.com"&gt;http://ahutech.com&lt;/a&gt;
+&lt;/p&gt;
+
+&lt;div class="job-description-container"&gt;
+&lt;div&gt;
+&lt;div class="badge" title="This company contacts applicants fast, usually within 24 hours."&gt;
+&lt;i class="fa fa-clock-o"&gt;&lt;/i&gt;
+&lt;span&gt;Replies within 24 hours&lt;/span&gt;
+&lt;/div&gt;
+&lt;/div&gt;
+&lt;div class="trix-content"&gt;
+&lt;div&gt;&lt;strong&gt;Job Description&lt;/strong&gt;&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;The Department of Health Services embedded IT team is looking for a Contractor to web applications for the Department of Homeless Services and Housing (DHSH). This will be a six-month term with the option of an extension.&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;strong&gt;The candidate should have the following skills:&lt;/strong&gt;&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Experience with ASP.Net Core, C#, MVC, Angular&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Experience with Power BI and SSRS&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Excellent research, analysis, and problem-solving skills.&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Experience with relational databases, SQL&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Strong analytical skills&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Excellent verbal and written communication skills&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Able to work independently and follow through on assignments.&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;strong&gt;Preferred Qualifications:&lt;/strong&gt;&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Strong experience with coding languages, databases, and data analytic tools.&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Interest in new and developing technologies.&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;·&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Experience in Electronic Health Records (E.H.R.) systems is a plus.&lt;/div&gt;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&lt;div&gt;
+&lt;strong&gt;Education: &lt;/strong&gt;Bachelor’s degree in Computer Science, Software Engineering, Information Technology, or equivalent experience. Relevant certifications is a plus.&lt;/div&gt;
+&lt;/div&gt;
+&lt;p&gt;This is a remote position.&lt;/p&gt;
+&lt;div class="job-compensation"&gt;
+          Compensation: $50.00 per hour
+        &lt;/div&gt;
+&lt;br&gt;&lt;br&gt;&lt;br&gt; &lt;div class="account_description"&gt;
+&lt;h1&gt;About Us&lt;/h1&gt; &lt;div&gt;&lt;strong&gt;AHU Technologies INC. &lt;/strong&gt;is an IT consulting and permanent staffing firm that meets and exceeds the evolving IT service needs of leading corporations within the United States. We have been providing IT solutions to customers from different industry sectors, helping them control costs and release internal resources to focus on strategic issues.&amp;nbsp;&lt;br&gt;&lt;br&gt;&lt;/div&gt; &lt;div&gt;&lt;strong&gt;AHU Technologies INC.&lt;/strong&gt; was co-founded by visionary young techno-commercial entrepreneurs who remain as our principal consultants. Maintaining working relationships with a cadre of other highly skilled independent consultants, we have a growing number of resources available for development projects. We are currently working on Various projects such as media entertainment, ERP Solutions, data warehousing, Web Applications, Telecommunications and medical to our clients all over the world.&lt;br&gt;&lt;br&gt;&lt;/div&gt;
+&lt;/div&gt;
+&lt;br&gt;&lt;/div&gt;
+
+&lt;p&gt;&lt;strong&gt;To apply:&lt;/strong&gt; &lt;a href="https://weworkremotely.com/remote-jobs/ahu-technologies-web-applications-developer-sacramento-ca"&gt;https://weworkremotely.com/remote-jobs/ahu-technologies-web-applications-developer-sacramento-ca&lt;/a&gt;&lt;/p&gt;
+</description>
+      <pubDate>Fri, 05 Jun 2026 20:37:07 +0000</pubDate>
+      <expires_at>Sun, 05 Jul 2026 20:37:07 +0000</expires_at>
+      <guid>https://weworkremotely.com/remote-jobs/ahu-technologies-web-applications-developer-sacramento-ca</guid>
+      <link>https://weworkremotely.com/remote-jobs/ahu-technologies-web-applications-developer-sacramento-ca</link>
+    </item>
+  </channel>
+</rss>

--- a/src/lib/crawler/remote_ok.test.ts
+++ b/src/lib/crawler/remote_ok.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseRemoteOkMainPageJobs } from "./remote_ok";
+import * as fs from "fs";
+import * as path from "path";
+
+const fixture = fs.readFileSync(
+  path.join(__dirname, "__fixtures__", "remoteok_test.html"),
+  "utf-8"
+);
+
+describe("parseRemoteOkMainPageJobs", () => {
+  const jobs = parseRemoteOkMainPageJobs(fixture);
+
+  it("parses all 4 jobs", () => {
+    expect(jobs).toHaveLength(4);
+  });
+
+  it("parses a job with div.salary and single div.location correctly", () => {
+    const job = jobs.find((j) => j.title === "Builder Chief")!;
+    expect(job).toBeDefined();
+    expect(job.location).toBe("🇺🇸 United States");
+    expect(job.salary).toBe("💰 $80k - $120k");
+    expect(job.url).toBe("https://remoteok.com/remote-jobs/remote-builder-chief-consultran-1132898");
+    expect(job.tags).toEqual(["Developer"]);
+    expect(job.updateTime).toBe("2026-06-05T20:03:15+00:00");
+  });
+
+  it("separates salary from location and filters employment type", () => {
+    const job = jobs.find((j) => j.title === "Senior Software Engineer")!;
+    expect(job.location).not.toContain("⏰");
+    expect(job.location).toContain("🇪🇺 Europe");
+    expect(job.location).toContain("🌎 North America");
+    expect(job.salary).toBe("💰 $90k - $130k");
+    expect(job.tags).toEqual(["Developer", "Train"]);
+  });
+
+  it("filters Part time employment type from location", () => {
+    const job = jobs.find((j) => j.title === "Entry Level Junior Trader")!;
+    expect(job.location).toBe("🌏 Worldwide");
+    expect(job.location).not.toContain("⏰");
+    expect(job.salary).toBe("💰 $50k - $60k");
+    expect(job.tags).toEqual(["Other", "Finance", "Analyst"]);
+  });
+
+  it("falls back to Premium placeholder when no div.salary", () => {
+    const job = jobs.find((j) => j.title === "Sourcing Specialist")!;
+    expect(job.location).toBe("🌏 Worldwide");
+    expect(job.salary).toBe("💰 Upgrade to Premium to see salary");
+    expect(job.tags).toEqual(["Sys Admin", "Recruiter", "Medical", "Non Tech"]);
+  });
+
+  it("includes job description text", () => {
+    for (const job of jobs) {
+      expect(job.description.length).toBeGreaterThan(0);
+      expect(typeof job.description).toBe("string");
+    }
+  });
+});

--- a/src/lib/crawler/remote_ok.ts
+++ b/src/lib/crawler/remote_ok.ts
@@ -32,13 +32,22 @@ export function parseRemoteOkMainPageJobs(htmlStr: string): CommonJob[] {
       const desc = htmlDiv.length ? htmlDiv.text() : mdDiv.length ? mdDiv.text() : "";
 
       const locDivs = header.find("div.location");
+      const salaryDiv = header.find("div.salary");
+
       const locs: string[] = [];
-      let salary = "";
-      locDivs.each((i, e) => {
+      locDivs.each((_i, e) => {
         const t = $(e).text().trim();
-        if (i === locDivs.length - 1) salary = t;
-        else locs.push(t);
+        if (!t) return;
+        if (/^⏰\s/.test(t)) return; // employment type (Part time, Full time, Contractor)
+        if (t.includes("Upgrade to Premium")) return; // "💰 Upgrade to Premium to see salary"
+        locs.push(t);
       });
+
+      let salary = salaryDiv.length ? salaryDiv.text().trim() : "";
+      if (!salary) {
+        const premium = header.find("div.location").filter((_i, e) => $(e).text().includes("Upgrade to Premium"));
+        if (premium.length) salary = premium.text().trim();
+      }
 
       const time = header.find("time").attr("datetime") ?? "";
       const tags: string[] = [];

--- a/src/lib/crawler/weworkremotely.test.ts
+++ b/src/lib/crawler/weworkremotely.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parseWeworkremotelyRSSResp } from "./weworkremotely";
+import * as fs from "fs";
+import * as path from "path";
+
+const fixture = fs.readFileSync(
+  path.join(__dirname, "__fixtures__", "weworkremotely_test.rss"),
+  "utf-8"
+);
+
+describe("parseWeworkremotelyRSSResp", () => {
+  const jobs = parseWeworkremotelyRSSResp(fixture);
+
+  it("parses all 3 jobs", () => {
+    expect(jobs).toHaveLength(3);
+  });
+
+  it("parses job title", () => {
+    expect(jobs[0].title).toBe(
+      "Varicent: Support Engineer – SQL & Web Applications (Remote - Mexico Only)"
+    );
+  });
+
+  it("parses URL", () => {
+    expect(jobs[0].url).toBe(
+      "https://weworkremotely.com/remote-jobs/varicent-support-engineer-sql-web-applications-remote-mexico-only"
+    );
+  });
+
+  it("parses location from region field", () => {
+    for (const job of jobs) {
+      expect(job.location).toBe("Anywhere in the World");
+    }
+  });
+
+  it("salary is always empty (not in RSS)", () => {
+    for (const job of jobs) {
+      expect(job.salary).toBe("");
+    }
+  });
+
+  it("parses tags from category field (space-separated)", () => {
+    expect(jobs[0].tags).toEqual(["Full-Stack", "Programming"]);
+  });
+
+  it("extracts description text from HTML", () => {
+    for (const job of jobs) {
+      expect(job.description.length).toBeGreaterThan(0);
+      expect(job.description).not.toContain("<");
+      expect(job.description).not.toContain(">");
+    }
+  });
+
+  it("parses updateTime from pubDate", () => {
+    for (const job of jobs) {
+      expect(job.updateTime).toBeTruthy();
+      expect(job.updateTime).toContain("2026");
+    }
+  });
+
+  it("returns empty array for empty RSS", () => {
+    const empty = '<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>';
+    expect(parseWeworkremotelyRSSResp(empty)).toEqual([]);
+  });
+
+  it("handles single item (not wrapped in array)", () => {
+    // Extract just the first <item>...</item> from the fixture
+    const match = fixture.match(/<item>[\s\S]*?<\/item>/);
+    expect(match).toBeTruthy();
+    const singleItemXml =
+      '<?xml version="1.0"?><rss version="2.0"><channel>' +
+      match![0] +
+      "</channel></rss>";
+    const jobs = parseWeworkremotelyRSSResp(singleItemXml);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].title).toBe(
+      "Varicent: Support Engineer – SQL & Web Applications (Remote - Mexico Only)"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three issues observed in production:

### 1. RemoteOK crawler: location/salary displacement
RemoteOK added a new `div.salary` CSS class for salary values and puts employment types (⏰ Part time, ⏰ Contractor) in `div.location`. The old heuristic (last `div.location` = salary) was broken.

**Fix**: Parse `div.salary` separately, filter employment type and premium placeholder from `div.location`.

### 2. Low match scores (<6) being stored and notified
The agent prompt said "score < 6 → do NOT submit" but the LLM often ignored it, submitting jobs with scores of 4, 3, and 1. No programmatic enforcement existed.

**Fix**: Three-layer defense:
- `submitEvaluation` tool rejects score < 6
- Match pipeline post-filters low-score results before DB write
- Agent prompt includes a self-review verification step

### 3. Added crawler test coverage
- Real website HTML/XML fixtures for RemoteOK and WeWorkRemotely
- 16 new tests covering all location/salary patterns